### PR TITLE
fix(table): 修复虚拟滚动列宽计算缺陷 (#29)

### DIFF
--- a/components/table/InternalTable.tsx
+++ b/components/table/InternalTable.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { INTERNAL_HOOKS } from './constant';
+import { INTERNAL_COLUMN_DEFAULT_WIDTH, INTERNAL_HOOKS } from './constant';
 import { convertChildrenToColumns } from './features/columns/useColumns';
 import type {
   ColumnsType,
@@ -280,12 +280,89 @@ const InternalTable = <RecordType extends AnyObject = AnyObject>(
   const tblRef = React.useRef<RcReference>(null);
 
   // ========================= Column Resize (hook needs rootRef) =========================
+  // 内部功能列（rowSelection / expand）无 key，不参与 resize 宽度分配，
+  // 但占据固定宽度——计入 resize 总宽，避免 scrollX 覆盖 scroll.x 后内容比容器宽。
+  // 宽度取值优先级：显式 columnWidth（数字 / 数字字符串 / 相对 scroll.x 的百分比）
+  // > RcTable 实测上报（CSS 覆盖也能跟随）> 默认 32/48
+  const [measuredInternalWidths, setMeasuredInternalWidths] = React.useState<
+    Record<string, number>
+  >({});
+  const handleAutoColumnMeasure = React.useCallback((columnType: string, width: number) => {
+    setMeasuredInternalWidths((prev) =>
+      prev[columnType] === width ? prev : { ...prev, [columnType]: width },
+    );
+  }, []);
+
+  const internalColumnsWidth = React.useMemo(() => {
+    const resolveWidth = (
+      raw: number | string | undefined,
+      measured: number | undefined,
+      fallback: number,
+    ): number => {
+      if (typeof raw === 'number' && raw > 0) {
+        return raw;
+      }
+      if (typeof raw === 'string') {
+        // 百分比：相对用户显式设置的 scroll.x 解析（与 useWidthColumns 的 parseColWidth 一致）
+        if (raw.endsWith('%') && typeof scroll?.x === 'number') {
+          const pct = Number.parseFloat(raw);
+          if (!Number.isNaN(pct)) {
+            return (scroll.x * pct) / 100;
+          }
+        }
+        const num = Number(raw);
+        if (!Number.isNaN(num) && num > 0) {
+          return num;
+        }
+      }
+      return measured ?? fallback;
+    };
+
+    let width = 0;
+    if (customizeRowSelection) {
+      width += resolveWidth(
+        (customizeRowSelection as TableRowSelection<RecordType>).columnWidth,
+        measuredInternalWidths.SELECTION_COLUMN,
+        INTERNAL_COLUMN_DEFAULT_WIDTH.SELECTION_COLUMN,
+      );
+    }
+    if (expandable?.expandedRowRender || expandedRowRender) {
+      width += resolveWidth(
+        expandable?.columnWidth,
+        measuredInternalWidths.EXPAND_COLUMN,
+        INTERNAL_COLUMN_DEFAULT_WIDTH.EXPAND_COLUMN,
+      );
+    }
+    return width;
+  }, [customizeRowSelection, expandable, expandedRowRender, measuredInternalWidths, scroll?.x]);
+
+  // 叶子列总数（含内部功能列），写入 wrapper 的 --columns-count CSS 变量：
+  // resize 竖线的 z-index 需要压过按列数计算的固定列/阴影层级（见 fixed.less）
+  const totalColumnCount = React.useMemo(() => {
+    let count = 0;
+    const walk = (cols: ColumnsType<RecordType>) => {
+      cols.forEach((col) => {
+        const subColumns = (col as { children?: ColumnsType<RecordType> }).children;
+        if (Array.isArray(subColumns) && subColumns.length > 0) {
+          walk(subColumns);
+        } else {
+          count += 1;
+        }
+      });
+    };
+    walk(mergedColumns);
+    if (customizeRowSelection) count += 1;
+    if (expandable?.expandedRowRender || expandedRowRender) count += 1;
+    return count;
+  }, [mergedColumns, customizeRowSelection, expandable, expandedRowRender]);
+
   const resizeResult = useResize({
     columns: mergedColumns as ColumnsType,
     enabled: resizable,
     containerRef: rootRef,
     onColumnResize: onColumnResizeProp,
     prefixCls,
+    extraFixedWidth: internalColumnsWidth,
   });
 
   const mergedComponents = React.useMemo<RcTableProps<RecordType>['components']>(() => {
@@ -963,7 +1040,11 @@ onKeyboardResize: resizeResult.setColumnWidth,
   // 竖线 DOM 通过 ref 直接操作，不需要 React state 驱动
 
   return (
-    <div ref={rootRef} className={wrappercls} style={style}>
+    <div
+      ref={rootRef}
+      className={wrappercls}
+      style={{ ...style, ['--columns-count' as any]: totalColumnCount }}
+    >
       {hasResizableColumns && (
         <div ref={resizeResult.lineRef} className={`${prefixCls}-resize-line`} />
       )}
@@ -976,6 +1057,7 @@ onKeyboardResize: resizeResult.setColumnWidth,
               {...tableProps}
               components={mergedComponents}
               scroll={mergedScroll}
+              onAutoColumnMeasure={handleAutoColumnMeasure}
               ref={tblRef}
               columns={finalColumns as RcTableProps<RecordType>['columns']}
               direction={'ltr'}

--- a/components/table/__tests__/Resize.test.tsx
+++ b/components/table/__tests__/Resize.test.tsx
@@ -150,6 +150,26 @@ describe('Resize — Handle Rendering', () => {
     expect(handles.length).toBe(2);
   });
 
+  it('sets --columns-count (incl. internal columns) on wrapper for resize line z-index', () => {
+    mockElementWidths(200, 0);
+    const cols: ColumnsType = [
+      { title: 'Name', dataIndex: 'name', key: 'name', width: 150, resizable: true },
+      { title: 'Age', dataIndex: 'age', key: 'age', width: 100 },
+    ];
+    const { container } = render(
+      <Table
+        dataSource={data}
+        columns={cols}
+        rowKey="key"
+        resizable
+        rowSelection={{ type: 'checkbox' }}
+      />,
+    );
+    const wrapper = container.querySelector<HTMLElement>('.ant-table-wrapper');
+    // 2 数据列 + 1 选择列 = 3（resize 竖线 z-index 需压过 2N+3 的阴影/固定层级）
+    expect(wrapper!.style.getPropertyValue('--columns-count')).toBe('3');
+  });
+
   it('renders resize line element when resizable', () => {
     mockElementWidths(200, 0);
     const { container } = render(
@@ -542,7 +562,31 @@ describe('Resize — Flex Distribution', () => {
     restoreElementWidths();
   });
 
-  it('distributes remainder to flex columns proportionally', () => {
+  it('distributes remainder to flex (no-width) columns, keeps explicit width exact', () => {
+    const cols: ColumnsType = [
+      { title: 'A', dataIndex: 'a', key: 'a', width: 100, resizable: true, minWidth: 60 },
+      { title: 'B', dataIndex: 'b', key: 'b', resizable: true, minWidth: 60 },
+      { title: 'C', dataIndex: 'c', key: 'c', resizable: true, minWidth: 60 },
+    ];
+    const { container } = render(
+      <Table dataSource={data} columns={cols} rowKey="key" resizable />,
+    );
+
+    // A 显式 100 固定不动；B/C 无宽 → 弹性列（base 60）
+    // remainder = 1000 - (100 + 60 + 60) = 780，B/C 按比例各得 390 → 450/450
+    const colgroup = container.querySelectorAll('colgroup col');
+    expect(colgroup.length).toBe(3);
+    const widths = Array.from(colgroup).map((col) => {
+      const style = col.getAttribute('style') || '';
+      return Number.parseInt(style.match(/(\d+)px/)?.[1] || '0', 10);
+    });
+    expect(widths[0]).toBe(100); // 显式 width 精确，不重分配
+    expect(widths[1]).toBe(450);
+    expect(widths[2]).toBe(450);
+    expect(widths[0] + widths[1] + widths[2]).toBe(1000);
+  });
+
+  it('grows proportionally when all columns have explicit width (grow-only)', () => {
     const cols: ColumnsType = [
       { title: 'A', dataIndex: 'a', key: 'a', width: 100, resizable: true, minWidth: 60 },
       { title: 'B', dataIndex: 'b', key: 'b', width: 100, resizable: true, minWidth: 60 },
@@ -552,38 +596,55 @@ describe('Resize — Flex Distribution', () => {
       <Table dataSource={data} columns={cols} rowKey="key" resizable />,
     );
 
-    // Total base = 300, container = 1000, remainder = 700
-    // ratio = 700 / 300 ≈ 2.333
-    // First flex (index 0, key 'a'): absorbs rounding, gets 100 + (700 - 233*2) = 100 + 234 = 334
-    // Second flex (index 1, key 'b'): 100 + floor(100 * 2.333) = 100 + 233 = 333
-    // Third flex (index 2, key 'c'): 100 + floor(100 * 2.333) = 100 + 233 = 333
+    // 全显式（总 300）< 容器 1000 → 等比放大未冻结列撑满：334/333/333
     const colgroup = container.querySelectorAll('colgroup col');
-    expect(colgroup.length).toBe(3);
-    const widths = Array.from(colgroup).map((col) => col.getAttribute('style'));
-    // Each should have a width style
-    expect(widths[0]).toContain('width');
-    expect(widths[1]).toContain('width');
-    expect(widths[2]).toContain('width');
-    // Total should equal containerWidth
-    const w0 = Number.parseInt(widths[0]!.match(/(\d+)px/)?.[1] || '0', 10);
-    const w1 = Number.parseInt(widths[1]!.match(/(\d+)px/)?.[1] || '0', 10);
-    const w2 = Number.parseInt(widths[2]!.match(/(\d+)px/)?.[1] || '0', 10);
-    expect(w0 + w1 + w2).toBe(1000);
+    const widths = Array.from(colgroup).map((col) => {
+      const style = col.getAttribute('style') || '';
+      return Number.parseInt(style.match(/(\d+)px/)?.[1] || '0', 10);
+    });
+    expect(widths[0] + widths[1] + widths[2]).toBe(1000);
+    widths.forEach((w) => expect(w).toBeGreaterThanOrEqual(100));
+  });
+
+  it('never shrinks explicit width columns; shrink hits no-width columns only (minWidth floor)', () => {
+    const cols: ColumnsType = [
+      { title: 'A', dataIndex: 'a', key: 'a', width: 300, resizable: true, minWidth: 60 },
+      { title: 'B', dataIndex: 'b', key: 'b', width: 300, resizable: true, minWidth: 60 },
+      { title: 'C', dataIndex: 'c', key: 'c', resizable: true, minWidth: 100 },
+    ];
+    const readWidths = (container: HTMLElement) =>
+      Array.from(container.querySelectorAll('colgroup col')).map((col) => {
+        const style = col.getAttribute('style') || '';
+        return Number.parseInt(style.match(/(\d+)px/)?.[1] || '0', 10);
+      });
+
+    // 容器 1000：C 为弹性列（base = minWidth 100），富余全给 C → 400
+    const { container: wide } = render(
+      <Table dataSource={data} columns={cols} rowKey="key" resizable />,
+    );
+    expect(readWidths(wide)).toEqual([300, 300, 400]);
+
+    // 容器 500：deficit = 700 - 500 = 200，只从 C 扣，下限 minWidth 100 → C = 100；
+    // A/B 显式列保持 300 不动，总宽 700 > 500（出现横向滚动）
+    mockElementWidths(200, 500);
+    const { container: narrow } = render(
+      <Table dataSource={data} columns={cols} rowKey="key" resizable />,
+    );
+    expect(readWidths(narrow)).toEqual([300, 300, 100]);
   });
 
   it('freezes all column widths after a drag (no flex redistribution)', () => {
     const onColumnResize = jest.fn();
     const cols: ColumnsType = [
       { title: 'A', dataIndex: 'a', key: 'a', width: 100, resizable: true, minWidth: 60 },
-      { title: 'B', dataIndex: 'b', key: 'b', width: 100, resizable: true, minWidth: 60 },
-      { title: 'C', dataIndex: 'c', key: 'c', width: 100, resizable: true, minWidth: 60 },
+      { title: 'B', dataIndex: 'b', key: 'b', resizable: true, minWidth: 60 },
+      { title: 'C', dataIndex: 'c', key: 'c', resizable: true, minWidth: 60 },
     ];
     const { container } = render(
       <Table dataSource={data} columns={cols} rowKey="key" resizable onColumnResize={onColumnResize} />,
     );
 
-    // Before drag: all columns are flex, total = containerWidth (1000)
-    // A = 334, B = 333, C = 333 (ratio-based distribution)
+    // Before drag: A 显式 100 固定；B/C 弹性各 450；total = 1000
     let colgroup = container.querySelectorAll('colgroup col');
     let widths = Array.from(colgroup).map((col) => {
       const style = col.getAttribute('style') || '';
@@ -596,16 +657,15 @@ describe('Resize — Flex Distribution', () => {
     expect(onColumnResize).toHaveBeenCalledWith('a', 250);
 
     // After drag: all columns are frozen at their pre-drag rendered widths
-    // A = 250 (user-dragged), B = 333 (frozen), C = 333 (frozen)
-    // Total = 250 + 333 + 333 = 916 ≠ 1000 (no flex redistribution)
+    // A = 250 (user-dragged), B = 450 (frozen), C = 450 (frozen)
     colgroup = container.querySelectorAll('colgroup col');
     widths = Array.from(colgroup).map((col) => {
       const style = col.getAttribute('style') || '';
       return Number.parseInt(style.match(/(\d+)px/)?.[1] || '0', 10);
     });
     expect(widths[0]).toBe(250); // Column A at user-dragged width
-    expect(widths[1]).toBe(333); // Column B frozen
-    expect(widths[2]).toBe(333); // Column C frozen
+    expect(widths[1]).toBe(450); // Column B frozen
+    expect(widths[2]).toBe(450); // Column C frozen
   });
 
   it('does not distribute remainder when no flex columns', () => {

--- a/components/table/__tests__/VirtualAutoColumnWidth.test.tsx
+++ b/components/table/__tests__/VirtualAutoColumnWidth.test.tsx
@@ -1,0 +1,282 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import '@testing-library/jest-dom/extend-expect';
+
+import { INTERNAL_COLUMN_DEFAULT_WIDTH } from '../constant';
+import { Table } from '../index';
+
+const generateData = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({ key: i, name: `Row ${i}`, value: i }));
+
+const columns = [
+  { key: 'name', dataIndex: 'name', title: 'Name', width: 200 },
+  { key: 'value', dataIndex: 'value', title: 'Value', width: 100 },
+];
+
+/**
+ * 虚拟模式下内部列（rowSelection / expand）未显式设置宽度时：
+ * - 表头 / summary 的 `<col>` 不得写内联宽度（交由 CSS 类驱动，支持 LESS 变量与用户覆盖）
+ * - body 单元格使用首帧提示值（选择列 32 / 展开列 48），真实宽度由测量管线接管
+ */
+describe('VirtualTable — auto width internal columns', () => {
+  it('rowSelection without columnWidth: header col has no inline width, body cell uses hint width', () => {
+    const { container } = render(
+      <Table
+        dataSource={generateData(50)}
+        columns={columns as any}
+        rowKey="key"
+        virtual
+        scroll={{ x: 2000, y: 400 }}
+        pagination={false}
+        rowSelection={{ type: 'checkbox' }}
+      />,
+    );
+
+    const selectionCol = container.querySelector('.ant-table-header col.ant-table-selection-col');
+    expect(selectionCol).toBeTruthy();
+    expect((selectionCol as HTMLElement).style.width).toBe('');
+
+    const selectionCell = container.querySelector<HTMLElement>(
+      '[data-row-key] .ant-table-selection-column',
+    );
+    expect(selectionCell).toBeTruthy();
+    expect(selectionCell!.style.width).toBe('32px');
+  });
+
+  it('rowSelection without columnWidth: narrow scroll.x should not crush selection column', () => {
+    const { container } = render(
+      <Table
+        dataSource={generateData(50)}
+        columns={columns as any}
+        rowKey="key"
+        virtual
+        scroll={{ x: 250, y: 400 }}
+        pagination={false}
+        rowSelection={{ type: 'checkbox' }}
+      />,
+    );
+
+    const selectionCell = container.querySelector<HTMLElement>(
+      '[data-row-key] .ant-table-selection-column',
+    );
+    expect(selectionCell).toBeTruthy();
+    expect(selectionCell!.style.width).toBe('32px');
+  });
+
+  it('rowSelection with explicit columnWidth: wins over hint, col keeps inline width', () => {
+    const { container } = render(
+      <Table
+        dataSource={generateData(50)}
+        columns={columns as any}
+        rowKey="key"
+        virtual
+        scroll={{ x: 300, y: 400 }}
+        pagination={false}
+        rowSelection={{ type: 'checkbox', columnWidth: 48 }}
+      />,
+    );
+
+    const selectionCol = container.querySelector<HTMLElement>(
+      '.ant-table-header col.ant-table-selection-col',
+    );
+    expect(selectionCol).toBeTruthy();
+    expect(selectionCol!.style.width).toBe('48px');
+
+    const selectionCell = container.querySelector<HTMLElement>(
+      '[data-row-key] .ant-table-selection-column',
+    );
+    expect(selectionCell!.style.width).toBe('48px');
+  });
+
+  it('expandedRowRender without columnWidth: header col has no inline width, body cell uses hint width', () => {
+    const { container } = render(
+      <Table
+        dataSource={generateData(50)}
+        columns={columns as any}
+        rowKey="key"
+        virtual
+        scroll={{ x: 2000, y: 400 }}
+        pagination={false}
+        expandable={{ expandedRowRender: () => <p>extra</p> }}
+      />,
+    );
+
+    const expandCol = container.querySelector<HTMLElement>(
+      '.ant-table-header col.ant-table-expand-icon-col',
+    );
+    expect(expandCol).toBeTruthy();
+    expect(expandCol!.style.width).toBe('');
+
+    const expandCell = container.querySelector<HTMLElement>(
+      '[data-row-key] .ant-table-row-expand-icon-cell',
+    );
+    expect(expandCell).toBeTruthy();
+    expect(expandCell!.style.width).toBe('48px');
+  });
+
+  it('expandable with explicit columnWidth: wins over hint', () => {
+    const { container } = render(
+      <Table
+        dataSource={generateData(50)}
+        columns={columns as any}
+        rowKey="key"
+        virtual
+        scroll={{ x: 300, y: 400 }}
+        pagination={false}
+        expandable={{ expandedRowRender: () => <p>extra</p>, columnWidth: 64 }}
+      />,
+    );
+
+    const expandCol = container.querySelector<HTMLElement>(
+      '.ant-table-header col.ant-table-expand-icon-col',
+    );
+    expect(expandCol!.style.width).toBe('64px');
+
+    const expandCell = container.querySelector<HTMLElement>(
+      '[data-row-key] .ant-table-row-expand-icon-cell',
+    );
+    expect(expandCell!.style.width).toBe('64px');
+  });
+
+  it('fixed summary: selection col has no inline width, merged cell renders across it', () => {
+    const { container } = render(
+      <Table
+        dataSource={generateData(50)}
+        columns={columns as any}
+        rowKey="key"
+        virtual
+        scroll={{ x: 2000, y: 400 }}
+        pagination={false}
+        rowSelection={{ type: 'checkbox' }}
+        summary={() => (
+          <Table.Summary fixed>
+            <Table.Summary.Row>
+              <Table.Summary.Cell index={0} colSpan={2}>
+                合计
+              </Table.Summary.Cell>
+              <Table.Summary.Cell index={2}>100</Table.Summary.Cell>
+            </Table.Summary.Row>
+          </Table.Summary>
+        )}
+      />,
+    );
+
+    const summaryCol = container.querySelector<HTMLElement>(
+      '.ant-table-summary col.ant-table-selection-col',
+    );
+    expect(summaryCol).toBeTruthy();
+    expect(summaryCol!.style.width).toBe('');
+
+    const mergedCell = container.querySelector('.ant-table-summary td[colspan="2"]');
+    expect(mergedCell).toBeTruthy();
+  });
+
+  it('fixed selection column: following fixed cell offset uses hint width', () => {
+    const fixedColumns = [
+      { key: 'name', dataIndex: 'name', title: 'Name', width: 200, fixed: 'start' as const },
+      { key: 'value', dataIndex: 'value', title: 'Value', width: 100 },
+    ];
+    const { container } = render(
+      <Table
+        dataSource={generateData(50)}
+        columns={fixedColumns as any}
+        rowKey="key"
+        virtual
+        scroll={{ x: 2000, y: 400 }}
+        pagination={false}
+        rowSelection={{ type: 'checkbox', fixed: 'start' }}
+      />,
+    );
+
+    // 选择列与 name 列均 fixed start；name 列的偏移 = 选择列宽（提示值 32）
+    const fixedCells = container.querySelectorAll<HTMLElement>(
+      '[data-row-key] .ant-table-cell-fix-start',
+    );
+    expect(fixedCells.length).toBeGreaterThanOrEqual(2);
+    expect(fixedCells[1]!.style.insetInlineStart).toBe('32px');
+  });
+
+  it('reserves auto column width when distributing space to no-width columns', () => {
+    const cols = [
+      { key: 'name', dataIndex: 'name', title: 'Name', width: 200 },
+      { key: 'value', dataIndex: 'value', title: 'Value' }, // 无 width → 弹性列
+    ];
+    const { container } = render(
+      <Table
+        dataSource={generateData(50)}
+        columns={cols as any}
+        rowKey="key"
+        virtual
+        scroll={{ x: 1000, y: 400 }}
+        pagination={false}
+        rowSelection={{ type: 'checkbox' }}
+      />,
+    );
+
+    // 弹性列 = 1000 - 32（选择列预留）- 200（显式列）= 768
+    const cells = container.querySelectorAll<HTMLElement>('[data-row-key]')[0]!.children;
+    expect((cells[2] as HTMLElement).style.width).toBe('768px');
+  });
+
+  it('scales up proportionally (grow-only) when all columns have explicit width', () => {
+    const { container } = render(
+      <Table
+        dataSource={generateData(50)}
+        columns={columns as any}
+        rowKey="key"
+        virtual
+        scroll={{ x: 1000, y: 400 }}
+        pagination={false}
+        rowSelection={{ type: 'checkbox' }}
+      />,
+    );
+
+    // 显式列总和 300，可用空间 1000 - 32 = 968，等比放大（只增不减）：
+    // name = floor(200 * 968 / 300) = 645，value = 968 - 645 = 323
+    const cells = container.querySelectorAll<HTMLElement>('[data-row-key]')[0]!.children;
+    expect((cells[1] as HTMLElement).style.width).toBe('645px');
+    expect((cells[2] as HTMLElement).style.width).toBe('323px');
+    // 选择列不受 scale-up 影响
+    expect((cells[0] as HTMLElement).style.width).toBe('32px');
+  });
+
+  it('showHeader=false: renders hidden probe carrying CSS width hooks for measurement', () => {
+    const { container } = render(
+      <Table
+        dataSource={generateData(50)}
+        columns={columns as any}
+        rowKey="key"
+        virtual
+        showHeader={false}
+        scroll={{ x: 2000, y: 400 }}
+        pagination={false}
+        rowSelection={{ type: 'checkbox' }}
+      />,
+    );
+
+    // 无表头时渲染隐藏探针（col 带 -selection-col 类，承载 CSS 宽度供测量）
+    const probeCol = container.querySelector('table[aria-hidden="true"] col.ant-table-selection-col');
+    expect(probeCol).toBeTruthy();
+    expect(probeCol!.closest('table')!.style.visibility).toBe('hidden');
+
+    // body 单元格使用首帧提示值（jsdom 测量为 0，保留提示值）
+    const selectionCell = container.querySelector<HTMLElement>(
+      '[data-row-key] .ant-table-selection-column',
+    );
+    expect(selectionCell!.style.width).toBe('32px');
+  });
+
+  it('hint widths stay in sync with LESS variables', () => {
+    const less = fs.readFileSync(path.join(__dirname, '../style/variables.less'), 'utf-8');
+
+    expect(less).toContain(
+      `@table-selection-column-width: ${INTERNAL_COLUMN_DEFAULT_WIDTH.SELECTION_COLUMN}px`,
+    );
+    expect(less).toContain(
+      `@table-expand-column-width: ${INTERNAL_COLUMN_DEFAULT_WIDTH.EXPAND_COLUMN}px`,
+    );
+  });
+});

--- a/components/table/components/FixedHolder/index.tsx
+++ b/components/table/components/FixedHolder/index.tsx
@@ -12,15 +12,17 @@ import type { ColumnsType, ColumnType, Direction, TableLayout } from '../../inte
 function useColumnWidth(colWidths: readonly number[], columCount: number) {
   return useMemo(() => {
     const cloneColumns: number[] = [];
+    let hasValue = false;
     for (let i = 0; i < columCount; i += 1) {
       const val = colWidths[i];
+      cloneColumns[i] = val;
       if (val !== undefined) {
-        cloneColumns[i] = val;
-      } else {
-        return null;
+        hasValue = true;
       }
     }
-    return cloneColumns;
+    // 逐列容忍 undefined（虚拟模式 auto 内部列不写内联宽度，由 CSS 类驱动）；
+    // 仅当全部列都未提供宽度时回退原始 colGroup
+    return hasValue ? cloneColumns : null;
   }, [colWidths.join('_'), columCount]);
 }
 

--- a/components/table/components/RcTable.tsx
+++ b/components/table/components/RcTable.tsx
@@ -55,6 +55,7 @@ import { useTimeoutLock } from '../features/virtual/useFrame';
 import useHover from '../features/hover/useHover';
 import useSticky from '../features/sticky/useSticky';
 import useStickyOffsets from '../features/fixed/useStickyOffsets';
+import useAutoColumnMeasure from '../features/virtual/useAutoColumnMeasure';
 import type {
   ColumnsType,
   ColumnType,
@@ -77,6 +78,7 @@ import Panel from './Panel';
 import StickyScrollBar from '../features/sticky/stickyScrollBar';
 
 import { getColumnsKey, validateValue, validNumberValue } from '../shared/utils/valueUtil';
+import { getAutoColumnHintWidth, getInternalColumnType, INTERNAL_COL_DEFINE, isAutoWidthColumn } from '../shared/utils/legacyUtil';
 
 export type CompareProps<T extends React.ComponentType<any>> = (
   prevProps: Readonly<React.ComponentProps<T>>,
@@ -191,6 +193,17 @@ export interface TableProps<RecordType = any>
    * !!! DO NOT USE IN PRODUCTION ENVIRONMENT !!!
    */
   measureRowRender?: (measureRow: React.ReactNode) => React.ReactNode;
+
+  /**
+   * @private Internal usage, may remove by refactor.
+   *
+   * !!! DO NOT USE IN PRODUCTION ENVIRONMENT !!!
+   *
+   * auto 内部列（rowSelection / expand 未显式设宽）实测宽度上报。
+   * 虚拟模式来自 useAutoColumnMeasure，非虚拟模式来自 MeasureRow，
+   * 统一在 colsWidths 更新后上报，供 InternalTable 的 resize 总宽账目使用。
+   */
+  onAutoColumnMeasure?: (columnType: string, width: number) => void;
 }
 
 function defaultEmpty() {
@@ -247,6 +260,7 @@ const Table = <RecordType extends DefaultRecordType>(
     internalRefs,
     tailor,
     getContainerWidth,
+    onAutoColumnMeasure,
 
     sticky,
     rowHoverable = true,
@@ -320,6 +334,9 @@ const Table = <RecordType extends DefaultRecordType>(
   // ====================== Column ======================
   const scrollX = scroll?.x;
   const [componentWidth, setComponentWidth] = React.useState(0);
+  // 列实测宽度（测量行 / 虚拟测量管线回写）。需先于 useColumns 声明：
+  // 虚拟模式下 auto 内部列的实测宽度会回传给 useWidthColumns 参与弹性分配。
+  const [colsWidths, updateColsWidths] = React.useState(() => new Map<React.Key, number>());
 
   const [columns, flattenColumns, flattenScrollX] = useColumns(
     {
@@ -336,6 +353,7 @@ const Table = <RecordType extends DefaultRecordType>(
       direction,
       scrollWidth: useInternalHooks && tailor && typeof scrollX === 'number' ? scrollX : undefined,
       clientWidth: componentWidth,
+      measuredWidths: colsWidths,
     },
     // `useColumns` guards the call with `if (transformColumns)`, so `null`
     // ("no transform") is a valid runtime value here.
@@ -396,14 +414,46 @@ const Table = <RecordType extends DefaultRecordType>(
   const scrollSummaryRef = React.useRef<HTMLDivElement>(null);
   const [shadowStart, setShadowStart] = React.useState(false);
   const [shadowEnd, setShadowEnd] = React.useState(false);
-  const [colsWidths, updateColsWidths] = React.useState(() => new Map<React.Key, number>());
 
   // Convert map to number width
   const colsKeys = getColumnsKey(flattenColumns);
-  const pureColWidths = colsKeys.map((columnKey) => colsWidths.get(columnKey));
+  const pureColWidths = flattenColumns.map((column, index) => {
+    const measured = colsWidths.get(colsKeys[index]);
+    // 虚拟模式 auto 内部列：实测值就绪前先填提示值，
+    // 避免首帧固定列偏移（stickyOffsets）按 0 计算造成闪动
+    if (
+      measured === undefined &&
+      typeof customizeScrollBody === 'function' &&
+      isAutoWidthColumn(column)
+    ) {
+      return getAutoColumnHintWidth(column);
+    }
+    return measured;
+  });
   // `Map.get` may yield `undefined` for unmeasured columns; all consumers
   // (`useStickyOffsets`, `FixedHolder`, `ColGroup`) tolerate that at runtime.
   const colWidths = React.useMemo(() => pureColWidths as number[], [pureColWidths.join('_')]);
+
+  // auto 内部列实测宽度上报（供 InternalTable 的 resize 总宽账目）：
+  // 虚拟模式由 useAutoColumnMeasure 写入，非虚拟由 MeasureRow 写入，统一在此上报
+  const autoMeasureReportedRef = React.useRef<Record<string, number>>({});
+  React.useEffect(() => {
+    if (!onAutoColumnMeasure) {
+      return;
+    }
+    const columnsKey = getColumnsKey(flattenColumns);
+    flattenColumns.forEach((column, index) => {
+      if (!isAutoWidthColumn(column)) {
+        return;
+      }
+      const columnType = getInternalColumnType(column) as string;
+      const width = colsWidths.get(columnsKey[index]);
+      if (width && autoMeasureReportedRef.current[columnType] !== width) {
+        autoMeasureReportedRef.current[columnType] = width;
+        onAutoColumnMeasure(columnType, width);
+      }
+    });
+  }, [colsWidths, flattenColumns, onAutoColumnMeasure]);
   const stickyOffsets = useStickyOffsets(colWidths, flattenColumns);
   const fixHeader = !!scroll && validateValue(scroll.y);
   const horizonScroll = (scroll && validateValue(mergedScrollX)) || Boolean(expandableConfig.fixed);
@@ -462,6 +512,18 @@ const Table = <RecordType extends DefaultRecordType>(
       return widths;
     });
   }, []);
+
+  // 虚拟模式：测量 auto 内部列（rowSelection / expand 未显式设宽）的真实 CSS 宽度，
+  // 回写 colsWidths 驱动 body 网格 / 固定列偏移 / 弹性分配。
+  // showHeader=false 时没有表头，改用隐藏探针（probeRef）承载 CSS 类宽度
+  const autoColumnProbeRef = React.useRef<HTMLTableElement>(null);
+  useAutoColumnMeasure(
+    typeof customizeScrollBody === 'function',
+    flattenColumns,
+    scrollHeaderRef,
+    onColumnResize,
+    autoColumnProbeRef,
+  );
 
   const [setScrollTarget, getScrollTarget] = useTimeoutLock<object | null>(null);
 
@@ -696,9 +758,26 @@ const Table = <RecordType extends DefaultRecordType>(
         onScroll: onInternalScroll,
       });
 
-      headerProps.colWidths = flattenColumns.map(({ width }, index) => {
+      // 表头最后一列需为纵向滚动条让出宽度；若最后一列是 auto 内部列
+      // （宽度由 CSS 驱动，不可内联调整），则由最后一个非 auto 列承担
+      let lastWidthColumnIndex = -1;
+      flattenColumns.forEach((column, index) => {
+        if (!isAutoWidthColumn(column)) {
+          lastWidthColumnIndex = index;
+        }
+      });
+
+      headerProps.colWidths = flattenColumns.map((column, index) => {
+        const { width } = column;
+
+        // auto 内部列（rowSelection / expand 未显式设宽）：不写内联宽度，
+        // 交由 CSS 类驱动（LESS 变量 / 用户覆盖均可生效），实测宽度由测量管线同步
+        if (isAutoWidthColumn(column)) {
+          return undefined as unknown as number;
+        }
+
         const colWidth =
-          index === flattenColumns.length - 1 ? (width as number) - scrollbarSize : width;
+          index === lastWidthColumnIndex ? (width as number) - scrollbarSize : width;
         if (typeof colWidth === 'number' && !Number.isNaN(colWidth)) {
           return colWidth;
         }
@@ -859,6 +938,42 @@ const Table = <RecordType extends DefaultRecordType>(
       ref={fullTableRef}
       {...dataProps}
     >
+      {/* showHeader=false 的虚拟表格没有表头可测 auto 内部列宽，
+          渲染隐藏探针承载同样的 CSS 类（col 类宽 + th padding）供测量 */}
+      {typeof customizeScrollBody === 'function' &&
+        showHeader === false &&
+        flattenColumns.some(isAutoWidthColumn) && (
+          <table
+            aria-hidden
+            ref={autoColumnProbeRef}
+            style={{
+              position: 'absolute',
+              insetInlineStart: -99999,
+              top: 0,
+              visibility: 'hidden',
+              tableLayout: 'fixed',
+              pointerEvents: 'none',
+            }}
+          >
+            <colgroup>
+              {flattenColumns.filter(isAutoWidthColumn).map((column, index) => {
+                const { columnType, ...restAdditionalProps } =
+                  (column as Record<string, any>)[INTERNAL_COL_DEFINE] || {};
+                return <col key={columnType || index} {...restAdditionalProps} />;
+              })}
+            </colgroup>
+            <tbody>
+              <tr>
+                {flattenColumns.filter(isAutoWidthColumn).map((column, index) => {
+                  const { columnType } = (column as Record<string, any>)[INTERNAL_COL_DEFINE] || {};
+                  return (
+                    <th key={columnType || index} className={column.className as string} />
+                  );
+                })}
+              </tr>
+            </tbody>
+          </table>
+        )}
       {title && (
         <Panel
           className={clsx(`${prefixCls}-title`, classNames?.title)}

--- a/components/table/components/VirtualTableBody/BodyGrid.tsx
+++ b/components/table/components/VirtualTableBody/BodyGrid.tsx
@@ -5,6 +5,8 @@ import * as React from 'react';
 import TableContext, { responseImmutable } from '../../shared/context/TableContext';
 import useFlattenRecords from '../../features/virtual/useFlattenRecords';
 import type { FlattenData } from '../../features/virtual/useFlattenRecords';
+import { getAutoColumnHintWidth, isAutoWidthColumn } from '../../shared/utils/legacyUtil';
+import { getColumnsKey } from '../../shared/utils/valueUtil';
 import type {
   ColumnType,
   OnCustomizeScroll,
@@ -43,6 +45,7 @@ const Grid = React.forwardRef<GridRef, GridProps>((props, ref) => {
     childrenColumnName,
     scrollX,
     direction,
+    colWidths,
   } = useContext(TableContext, [
     'flattenColumns',
     'onColumnResize',
@@ -52,6 +55,7 @@ const Grid = React.forwardRef<GridRef, GridProps>((props, ref) => {
     'childrenColumnName',
     'scrollX',
     'direction',
+    'colWidths',
   ]);
 
   const {
@@ -70,13 +74,22 @@ const Grid = React.forwardRef<GridRef, GridProps>((props, ref) => {
 
   // ========================== Column ==========================
   const columnsWidth = React.useMemo<[key: React.Key, width: number, total: number][]>(() => {
+    const columnsKey = getColumnsKey(flattenColumns);
     let total = 0;
-    return flattenColumns.map(({ width, minWidth, key }) => {
-      const finalWidth = Math.max((width as number) || 0, (minWidth as number) || 0);
+    return flattenColumns.map((column, index) => {
+      const { width, minWidth } = column;
+      // auto 内部列（rowSelection / expand 未显式设宽）：取测量管线回写的真实
+      // CSS 宽度，未测量到时回退首帧提示值。
+      // 普通列：与表头同源于 useWidthColumns 填充后的 width（resize 渲染宽）。
+      // 不能用 max(width, minWidth)：resize 收缩后的渲染宽可能小于 minWidth，
+      // max 兜底会让 body 单元格比表头 col 宽，导致表头/body 列错位。
+      const finalWidth = isAutoWidthColumn(column)
+        ? colWidths[index] || getAutoColumnHintWidth(column)
+        : (width as number) || (minWidth as number) || 0;
       total += finalWidth;
-      return [key as React.Key, finalWidth, total];
+      return [columnsKey[index], finalWidth, total];
     });
-  }, [flattenColumns]);
+  }, [flattenColumns, colWidths]);
 
   const columnsOffset = React.useMemo<number[]>(
     () => columnsWidth.map((colWidth) => colWidth[2]),

--- a/components/table/constant.ts
+++ b/components/table/constant.ts
@@ -1,3 +1,24 @@
 export const EXPAND_COLUMN = {} as const;
 
 export const INTERNAL_HOOKS = 'rc-table-internal-hook';
+
+/**
+ * 内部列（rowSelection / expand）未显式设置宽度时的首帧提示宽度。
+ * 虚拟模式下这些列的真实宽度由 CSS 类驱动（LESS 变量 / 用户覆盖均可生效），
+ * 并经测量管线同步进网格计算；此常量仅用于首次渲染与无法测量的环境（如 jsdom、
+ * showHeader=false），不是宽度的事实源。
+ * 取值需与 style/variables.less 中对应变量保持一致。
+ */
+export const INTERNAL_COLUMN_DEFAULT_WIDTH: Record<string, number> = {
+  // @table-selection-column-width
+  SELECTION_COLUMN: 32,
+  // @table-expand-column-width
+  EXPAND_COLUMN: 48,
+};
+
+/**
+ * 虚拟模式下未设 width 列的最小填充宽度。
+ * antd 原生行为在空间不足时会把无宽列压到 1px（不可用），此处给 60px 保底；
+ * 列上显式设置的 minWidth 优先于此值。
+ */
+export const VIRTUAL_MISSING_WIDTH_COLUMN_MIN = 60;

--- a/components/table/features/columns/useColumns.tsx
+++ b/components/table/features/columns/useColumns.tsx
@@ -112,6 +112,7 @@ function useColumns<RecordType>(
     fixed,
     scrollWidth,
     clientWidth,
+    measuredWidths,
   }: {
     prefixCls?: string;
     columns?: ColumnsType<RecordType>;
@@ -131,6 +132,8 @@ function useColumns<RecordType>(
     fixed?: FixedType;
     scrollWidth?: number | null;
     expandedRowOffset?: number;
+    /** auto 内部列的实测宽度（虚拟模式测量管线回写），用于弹性分配时为其预留空间 */
+    measuredWidths?: ReadonlyMap<Key, number>;
   },
   transformColumns: (columns: ColumnsType<RecordType>) => ColumnsType<RecordType>,
 ): [
@@ -275,6 +278,7 @@ function useColumns<RecordType>(
     // verbatim, so pass the value through as-is.
     scrollWidth as number,
     clientWidth,
+    measuredWidths,
   );
 
   return [mergedColumns, filledColumns, realScrollWidth];

--- a/components/table/features/columns/useWidthColumns.tsx
+++ b/components/table/features/columns/useWidthColumns.tsx
@@ -72,7 +72,7 @@ export default function useWidthColumns(
         missWidthCount * VIRTUAL_MISSING_WIDTH_COLUMN_MIN,
       );
       let restCount = missWidthCount;
-      const avgWidth = restWidth / missWidthCount;
+      const avgWidth = missWidthCount > 0 ? restWidth / missWidthCount : 0;
 
       let realTotal = 0;
 

--- a/components/table/features/columns/useWidthColumns.tsx
+++ b/components/table/features/columns/useWidthColumns.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react';
-import type { ColumnsType } from '../../interface';
+import { VIRTUAL_MISSING_WIDTH_COLUMN_MIN } from '../../constant';
+import type { ColumnsType, Key } from '../../interface';
+import { getAutoColumnHintWidth, isAutoWidthColumn } from '../../shared/utils/legacyUtil';
+import { getColumnsKey } from '../../shared/utils/valueUtil';
 
 function parseColWidth(totalWidth: number, width: string | number = '') {
   if (typeof width === 'number') {
@@ -14,20 +17,42 @@ function parseColWidth(totalWidth: number, width: string | number = '') {
 
 /**
  * Fill all column with width
+ *
+ * auto 内部列（rowSelection / expand 未显式设宽）不参与弹性分配：
+ * 宽度保持 undefined（虚拟模式下由 CSS 类驱动 + 测量管线接管），
+ * 仅以 测量值 / 首帧提示值 计入总宽，保证其余列分配时为其留出空间。
  */
 export default function useWidthColumns(
   flattenColumns: ColumnsType<any>,
   scrollWidth: number,
   clientWidth: number,
+  measuredWidths?: ReadonlyMap<Key, number>,
 ) {
   return React.useMemo<[columns: ColumnsType<any>, realScrollWidth: number]>(() => {
     // Fill width if needed
     if (scrollWidth && scrollWidth > 0) {
+      const columnsKey = getColumnsKey(flattenColumns);
+
+      // auto 列的已知宽度（测量值优先，回退首帧提示值）；非 auto 列返回 null
+      const getAutoWidth = (col: any, index: number): number | null => {
+        if (!isAutoWidthColumn(col)) {
+          return null;
+        }
+        return measuredWidths?.get(columnsKey[index]) || getAutoColumnHintWidth(col);
+      };
+
       let totalWidth = 0;
+      let autoTotal = 0;
       let missWidthCount = 0;
 
       // collect not given width column
-      flattenColumns.forEach((col: any) => {
+      flattenColumns.forEach((col: any, index: number) => {
+        const autoWidth = getAutoWidth(col, index);
+        if (autoWidth != null) {
+          autoTotal += autoWidth;
+          return;
+        }
+
         const colWidth = parseColWidth(scrollWidth, col.width);
 
         if (colWidth) {
@@ -39,16 +64,27 @@ export default function useWidthColumns(
 
       // Fill width
       const maxFitWidth = Math.max(scrollWidth, clientWidth);
-      let restWidth = Math.max(maxFitWidth - totalWidth, missWidthCount);
+      // 非 auto 列的可用空间：为 auto 列预留宽度
+      const availWidth = maxFitWidth - autoTotal;
+      // 无宽列填充下限：空间不足时每列保底 60（antd 原生会压到 1px，不可用）
+      let restWidth = Math.max(
+        availWidth - totalWidth,
+        missWidthCount * VIRTUAL_MISSING_WIDTH_COLUMN_MIN,
+      );
       let restCount = missWidthCount;
       const avgWidth = restWidth / missWidthCount;
 
       let realTotal = 0;
 
-      const filledColumns = flattenColumns.map((col: any) => {
+      const filledColumns = flattenColumns.map((col: any, index: number) => {
         const clone = {
           ...col,
         };
+
+        if (getAutoWidth(col, index) != null) {
+          // auto 列保持 width undefined，不参与填充
+          return clone;
+        }
 
         const colWidth = parseColWidth(scrollWidth, clone.width);
 
@@ -57,7 +93,11 @@ export default function useWidthColumns(
         } else {
           const colAvgWidth = Math.floor(avgWidth);
 
-          clone.width = restCount === 1 ? restWidth : colAvgWidth;
+          // 列上显式 minWidth 优先于平均填充值
+          clone.width = Math.max(
+            restCount === 1 ? restWidth : colAvgWidth,
+            (clone.minWidth as number) || 0,
+          );
 
           restWidth -= colAvgWidth;
           restCount -= 1;
@@ -68,25 +108,40 @@ export default function useWidthColumns(
         return clone;
       });
 
-      // If realTotal is less than clientWidth,
-      // We need extend column width
-      if (realTotal < maxFitWidth) {
-        const scale = maxFitWidth / realTotal;
+      // antd 原生 scale-up：列宽总和小于可用空间时，等比放大撑满（只增不减）。
+      // 仅放大非 auto 列，目标为 availWidth（已为 auto 列预留空间）；
+      // 最后一个非 auto 列吸收舍入误差（auto 列可能是最后一列，且其 width
+      // 为 undefined，Math.floor(undefined * scale) = NaN，必须跳过）
+      if (realTotal > 0 && realTotal < availWidth) {
+        const scale = availWidth / realTotal;
 
-        restWidth = maxFitWidth;
+        restWidth = availWidth;
 
-        filledColumns.forEach((col: any, index) => {
+        let lastFillIndex = -1;
+        filledColumns.forEach((col: any, index: number) => {
+          if (getAutoWidth(col, index) == null) {
+            lastFillIndex = index;
+          }
+        });
+
+        filledColumns.forEach((col: any, index: number) => {
+          if (getAutoWidth(col, index) != null) {
+            return;
+          }
+
           const colWidth = Math.floor(col.width * scale);
 
-          col.width = index === filledColumns.length - 1 ? restWidth : colWidth;
+          col.width = index === lastFillIndex ? restWidth : colWidth;
 
           restWidth -= colWidth;
         });
+
+        realTotal = availWidth;
       }
 
-      return [filledColumns, Math.max(realTotal, maxFitWidth)];
+      return [filledColumns, realTotal + autoTotal];
     }
 
     return [flattenColumns, scrollWidth];
-  }, [flattenColumns, scrollWidth, clientWidth]);
+  }, [flattenColumns, scrollWidth, clientWidth, measuredWidths]);
 }

--- a/components/table/features/resize/useResize.ts
+++ b/components/table/features/resize/useResize.ts
@@ -13,6 +13,12 @@ export interface UseResizeOptions {
   onColumnResize?: (key: Key, width: number) => void;
   /** 样式前缀，用于查找表格本体容器 */
   prefixCls: string;
+  /**
+   * 内部功能列（rowSelection / expand）占据的固定宽度。
+   * 这些列无 key/dataIndex，不参与宽度分配与拖拽，但占据表格宽度；
+   * 计入总宽可避免 scrollX 覆盖 scroll.x 后内容比预期宽出内部列宽。
+   */
+  extraFixedWidth?: number;
 }
 
 /**
@@ -30,16 +36,19 @@ function getColumnKey(col: ColumnType): Key | null {
  *
  * 核心交互策略：
  *
- * **初始弹性分配**：
- * - 初始所有列为"弹性列"，按 baseWidth 比例分配容器剩余空间，填满容器
- * - remainder > 0：弹性列膨胀；remainder < 0：弹性列收缩（不低于 minWidth）
+ * **初始弹性分配**（显式 width 列只增不减）：
+ * - 显式设了 width 的列：宽度是下限，绝不收缩；容器有富余且没有无宽列时，
+ *   所有未冻结列等比放大撑满容器（对齐 antd useWidthColumns 的 scale-up）
+ * - 未设 width 的列为"弹性列"（基础宽 defaultMinWidth）：富余优先膨胀给它，
+ *   容器不足时先收缩它（下限各自的 minWidth），显式列不动
+ * - 收缩到底仍超出容器时出现横向滚动条
  *
  * **拖拽冻结**：
  * - 松手时，将所有列的 baseWidth 冻结为当前渲染宽度，并全部标记为固定列
  * - 这样松手后 remainder ≈ 0，不会触发 flex 重分配
  * - 列边界精确停留在鼠标位置（跟手）
  * - 总宽 = 渲染宽度之和，可能 ≠ containerWidth（出现滚动条或空白）
- * - 用户可调用 resetColumnWidths 恢复所有列为弹性列
+ * - 用户可调用 resetColumnWidths 恢复无宽列为弹性列
  *
  * **拖拽精度**：
  * - 使用 th.offsetWidth（实际渲染宽度）作为拖拽起点
@@ -57,6 +66,7 @@ function useResize({
   containerRef,
   onColumnResize,
   prefixCls,
+  extraFixedWidth = 0,
 }: UseResizeOptions) {
   // 扁平化列（仅叶子列可以 resize）
   const flattenColumns = React.useMemo(() => {
@@ -221,21 +231,21 @@ function useResize({
   // renderWidths: 实际传给 colgroup 的宽度
   // scrollX: renderWidths 的总和，用于覆盖 scroll.x
   //
-  // 策略（对齐 Element Plus updateColumnsWidth）：
-  //   1. 收集所有列的 baseWidth，计算 totalWidth
-  //   2. flexColumns = 未在 resizedKeys 中的列（弹性列）
+  // 策略（显式 width 列只增不减，对齐 antd useWidthColumns）：
+  //   1. 收集所有列的 baseWidth，计算 totalWidth（含内部功能列固定宽）
+  //   2. flexColumns = 未显式设 width 且未在 resizedKeys 中的列（弹性列）
   //   3. remainder = containerWidth - totalWidth
-  //   4. remainder ≠ 0 且有弹性列时，按 baseWidth 比例分配 remainder 给弹性列
-  //      - remainder > 0：弹性列膨胀（吸收剩余空间）
-  //      - remainder < 0：弹性列收缩（让出超出空间），但不低于 minWidth
-  //      - 第一个弹性列吸收舍入误差，确保 totalRender === containerWidth
-  //   5. remainder = 0 或无弹性列时，使用 baseWidth
+  //   4. remainder > 0（膨胀）：富余优先按 baseWidth 比例分配给弹性列；
+  //      无弹性列（全是显式 width 列）时等比放大所有未冻结列撑满容器
+  //   5. remainder < 0（收缩）：只从弹性列扣除，下限各自的 minWidth；
+  //      显式 width 列不缩，扣完仍超出则出现横向滚动条
+  //   6. remainder = 0 时，使用 baseWidth
   const { renderWidths, scrollX } = React.useMemo(() => {
     const map = new Map<Key, number>();
 
-    // 1. 收集每列的基础宽度
-    const entries: { key: Key; width: number; flex: boolean }[] = [];
-    let totalWidth = 0;
+    // 1. 收集每列的基础宽度（totalWidth 含内部功能列固定宽，确保弹性分配为其预留空间）
+    const entries: { key: Key; width: number; flex: boolean; minWidth: number }[] = [];
+    let totalWidth = extraFixedWidth;
 
     flattenColumns.forEach((col) => {
       const key = getColumnKey(col);
@@ -244,72 +254,78 @@ function useResize({
       const mapWidth = columnWidths.get(key);
       // Guard against NaN: non-numeric string widths are treated as missing
       const rawW = col.width != null ? Number(col.width) : 0;
-      // 未设 width 且未被拖拽冻结的列：以 defaultMinWidth 为基础宽度参与弹性分配，
-      // 避免渲染宽度被覆盖为 0 而塌陷为 0~1px
-      const baseWidth = mapWidth ?? (Number.isNaN(rawW) || rawW <= 0 ? defaultMinWidth : rawW);
-      const flex = !resizedKeys.has(key) && baseWidth > 0;
-      entries.push({ key, width: baseWidth, flex });
+      const hasExplicitWidth = !Number.isNaN(rawW) && rawW > 0;
+      // 未设 width 且未被拖拽冻结的列：以 minWidth（若有，否则 defaultMinWidth）为
+      // 基础宽度参与弹性分配，避免渲染宽度被覆盖为 0 而塌陷为 0~1px
+      const baseWidth = mapWidth ?? (hasExplicitWidth ? rawW : Math.max(defaultMinWidth, col.minWidth ?? 0));
+      // 弹性列 = 未显式设 width 且未被拖拽冻结的列；
+      // 显式 width 列只增不减（膨胀时等比放大，收缩时不动）
+      const flex = !resizedKeys.has(key) && !hasExplicitWidth;
+      entries.push({ key, width: baseWidth, flex, minWidth: col.minWidth ?? defaultMinWidth });
       totalWidth += baseWidth;
     });
 
-    // 2. 收集弹性列
+    // 2. 收集弹性列（无宽列，膨胀/收缩都优先作用于它们）
     const flexEntries = entries.filter((e) => e.flex);
 
     // 3. 计算剩余空间
-    const remainder =
-      containerWidth > 0 && flexEntries.length > 0 ? containerWidth - totalWidth : 0;
+    const remainder = containerWidth > 0 ? containerWidth - totalWidth : 0;
 
-    // 4. 分配（remainder > 0 膨胀，remainder < 0 收缩）
-    if (remainder !== 0) {
-      const flexTotal = flexEntries.reduce((sum, e) => sum + e.width, 0);
+    // 4. 分配
+    if (remainder > 0) {
+      // 膨胀：富余优先给弹性列；全是显式 width 列时，等比放大所有未冻结列
+      // 撑满容器（对齐 antd useWidthColumns 的 scale-up：显式列只增不减）。
+      // 冻结列（已拖拽）不参与，保证松手后的布局不漂移。
+      const growEntries =
+        flexEntries.length > 0 ? flexEntries : entries.filter((e) => !resizedKeys.has(e.key));
+      const growTotal = growEntries.reduce((sum, e) => sum + e.width, 0);
 
-      if (remainder > 0) {
-        // 膨胀：按 baseWidth 比例分配剩余空间
-        const ratio = remainder / flexTotal;
+      if (growEntries.length > 0 && growTotal > 0) {
+        const ratio = remainder / growTotal;
         let assigned = 0;
-        flexEntries.forEach((entry, index) => {
-          if (index === 0) return; // 第一个弹性列最后计算，吸收舍入误差
-          const flex = Math.floor(entry.width * ratio);
-          assigned += flex;
-          map.set(entry.key, entry.width + flex);
+        growEntries.forEach((entry, index) => {
+          if (index === 0) return; // 第一个列最后计算，吸收舍入误差
+          const grow = Math.floor(entry.width * ratio);
+          assigned += grow;
+          map.set(entry.key, entry.width + grow);
         });
-        // 第一个弹性列 = remainder - 其他弹性列已分配的量
-        const firstFlex = remainder - assigned;
-        map.set(flexEntries[0].key, flexEntries[0].width + firstFlex);
-      } else {
-        // 收缩：按 baseWidth 比例从弹性列中扣除超出空间（对齐 Element Plus）
-        const deficit = -remainder; // 需要扣除的总量
-        const ratio = deficit / flexTotal;
-
-        // 先计算每列的扣除量，确保不低于 minWidth
-        let actualDeducted = 0;
-        const deductions = flexEntries.map((entry, index) => {
-          if (index === 0) return 0; // 第一个弹性列最后计算
-          const maxDeduct = Math.max(0, entry.width - defaultMinWidth);
-          const deduct = Math.min(Math.floor(entry.width * ratio), maxDeduct);
-          actualDeducted += deduct;
-          return deduct;
-        });
-
-        // 第一个弹性列扣除剩余量，但不低于 minWidth
-        const firstDeduct = Math.min(
-          deficit - actualDeducted,
-          Math.max(0, flexEntries[0].width - defaultMinWidth),
-        );
-        deductions[0] = firstDeduct;
-        actualDeducted += firstDeduct;
-
-        // 应用扣除
-        flexEntries.forEach((entry, index) => {
-          map.set(entry.key, entry.width - deductions[index]);
-        });
-
-        // 如果弹性列全部到 minWidth 仍然不够扣除，totalRender > containerWidth，出现滚动条
+        map.set(growEntries[0].key, growEntries[0].width + (remainder - assigned));
       }
+    } else if (remainder < 0 && flexEntries.length > 0) {
+      // 收缩：只从无宽弹性列扣除，下限各自的 minWidth（显式 width 列一像素不动）
+      const deficit = -remainder; // 需要扣除的总量
+      const flexTotal = flexEntries.reduce((sum, e) => sum + e.width, 0);
+      const ratio = deficit / flexTotal;
+
+      // 先计算每列的扣除量，确保不低于 minWidth
+      let actualDeducted = 0;
+      const deductions = flexEntries.map((entry, index) => {
+        if (index === 0) return 0; // 第一个弹性列最后计算
+        const maxDeduct = Math.max(0, entry.width - entry.minWidth);
+        const deduct = Math.min(Math.floor(entry.width * ratio), maxDeduct);
+        actualDeducted += deduct;
+        return deduct;
+      });
+
+      // 第一个弹性列扣除剩余量，但不低于 minWidth
+      const firstDeduct = Math.min(
+        deficit - actualDeducted,
+        Math.max(0, flexEntries[0].width - flexEntries[0].minWidth),
+      );
+      deductions[0] = firstDeduct;
+
+      // 应用扣除
+      flexEntries.forEach((entry, index) => {
+        map.set(entry.key, entry.width - deductions[index]);
+      });
+
+      // 弹性列全部到 minWidth 仍不够扣除：totalRender > containerWidth，
+      // 出现横向滚动条（显式 width 列依然不缩）
     }
 
     // 非弹性列 + remainder = 0 时的弹性列，使用 baseWidth
-    let totalRender = 0;
+    // totalRender 含内部功能列固定宽（extraFixedWidth）
+    let totalRender = extraFixedWidth;
     entries.forEach((entry) => {
       if (!map.has(entry.key)) {
         map.set(entry.key, entry.width);
@@ -322,7 +338,7 @@ function useResize({
     const sx = containerWidth > 0 ? totalRender : null;
 
     return { renderWidths: map, scrollX: sx };
-  }, [flattenColumns, columnWidths, containerWidth, resizedKeys, defaultMinWidth]);
+  }, [flattenColumns, columnWidths, containerWidth, resizedKeys, defaultMinWidth, extraFixedWidth]);
 
   // 同步 renderWidths 到 ref（供 onUp 中读取当前渲染宽度）
   renderWidthsRef.current = renderWidths;

--- a/components/table/features/selection/useSelection.tsx
+++ b/components/table/features/selection/useSelection.tsx
@@ -733,7 +733,7 @@ const useSelection = <RecordType extends AnyObject = AnyObject>(
         render: renderSelectionCell,
         onCell: rowSelection.onCell,
         align: rowSelection.align,
-        [INTERNAL_COL_DEFINE]: { className: columnCls },
+        [INTERNAL_COL_DEFINE]: { className: columnCls, columnType: 'SELECTION_COLUMN' },
       };
 
       return cloneColumns.map((col) => (col === SELECTION_COLUMN ? selectionColumn : col));

--- a/components/table/features/virtual/useAutoColumnMeasure.ts
+++ b/components/table/features/virtual/useAutoColumnMeasure.ts
@@ -1,0 +1,77 @@
+import type * as React from 'react';
+import useLayoutEffect from '../../../_util/hooks/useLayoutEffect';
+import type { ColumnType } from '../../interface';
+import { isAutoWidthColumn } from '../../shared/utils/legacyUtil';
+import { getColumnsKey } from '../../shared/utils/valueUtil';
+
+/**
+ * 虚拟模式下 auto 内部列（rowSelection / expand 未显式设宽）的宽度测量。
+ *
+ * 这些列的表头 `<col>` 不写内联宽度，列宽完全由 CSS 类决定（LESS 变量、
+ * modifyVars、用户自定义覆盖均可生效）。此处测量表头单元格的真实渲染宽度
+ * （th.offsetWidth，表头为 table-layout: fixed，th 跟随 col），并写入
+ * onColumnResize 管线，驱动 body 网格列宽、固定列偏移与弹性分配。
+ *
+ * ResizeObserver 持续监听：运行时主题切换 / CSS 变化会自动跟随。
+ * 测量结果为 0 时（jsdom、表格隐藏）不写回，保留首帧提示值。
+ */
+export default function useAutoColumnMeasure<RecordType>(
+  enabled: boolean,
+  flattenColumns: readonly ColumnType<RecordType>[],
+  headerRef: React.RefObject<HTMLDivElement | null>,
+  onColumnResize: (key: React.Key, width: number) => void,
+  /** showHeader=false 时无表头可测，改用隐藏探针（承载同样的 CSS 类宽度） */
+  probeRef?: React.RefObject<HTMLElement | null>,
+) {
+  useLayoutEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    const headerEle = headerRef.current ?? probeRef?.current ?? null;
+    if (!headerEle) {
+      return;
+    }
+
+    const columnsKey = getColumnsKey(flattenColumns);
+    const measureTargets: { th: HTMLElement; key: React.Key }[] = [];
+
+    flattenColumns.forEach((col, index) => {
+      if (!isAutoWidthColumn(col)) {
+        return;
+      }
+
+      // 内部列的 column.className 会打在表头 th 上（Header.tsx），取首个 class 定位
+      const className = (col.className || '').split(' ')[0];
+      if (!className) {
+        return;
+      }
+      const th = headerEle.querySelector<HTMLElement>(`th.${className}`);
+      if (!th) {
+        return;
+      }
+
+      measureTargets.push({ th, key: columnsKey[index] });
+    });
+
+    if (!measureTargets.length) {
+      return;
+    }
+
+    const measure = () => {
+      measureTargets.forEach(({ th, key }) => {
+        const width = th.offsetWidth;
+        if (width > 0) {
+          onColumnResize(key, width);
+        }
+      });
+    };
+    measure();
+
+    const observer = new ResizeObserver(measure);
+    measureTargets.forEach(({ th }) => observer.observe(th));
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [enabled, flattenColumns, headerRef, probeRef, onColumnResize]);
+}

--- a/components/table/index.md
+++ b/components/table/index.md
@@ -8,7 +8,7 @@ demo:
 
 # Table 表格
 
-企业级表格组件，完全对齐 antd v5 Table API，支持 React 17 + LESS。
+企业级表格组件，提供大数据量虚拟滚动、固定列与粘性表头、列宽拖拽、可编辑单元格、批量编辑等能力。
 
 ## 何时使用
 
@@ -87,9 +87,14 @@ demo:
 
 <code src="./demos/comprehensive.tsx" description="固定列 + 固定表头 + 行展开 + 合计行 + 排序 的综合示例。">综合示例</code>
 
-## 列宽拖拽
+## 列宽
 
-<code src="./demos/resize.tsx" description="通过 `resizable` 属性和 `column.resize` 配置实现表头拖拽改变列宽。鼠标悬停到列右边框高亮，拖拽时显示竖线指示器，松开后改变宽度。">拖拽调整列宽</code>
+设置 `column.width` 控制列宽。列宽分配遵循一个原则：**`width` 是下限，不会变窄，只会变宽**——容器有富余空间时，优先分配给未设置 `width` 的列；若所有列都设置了 `width`，则按比例放大撑满容器。
+
+- 未设置 `width` 的列是弹性列：富余时优先变宽，容器不足时优先收缩（最小收缩到 `minWidth`，默认 `60`），仍超出容器时出现横向滚动条。
+- 选择列 / 展开列默认宽 `32px` / `48px`，可通过 `rowSelection.columnWidth` / `expandable.columnWidth` 或 Less 变量 `@table-selection-column-width` / `@table-expand-column-width` 调整，虚拟滚动下自动跟随。
+
+<code src="./demos/resize.tsx" description="通过 `resizable` 属性和列上的 `minWidth` / `maxWidth` 配置实现表头拖拽改变列宽。鼠标悬停到列右边框高亮，拖拽时显示竖线指示器，松开后改变宽度；拖拽过的列会冻结在拖拽后的宽度。">拖拽调整列宽</code>
 
 ## 可编辑单元格
 
@@ -167,9 +172,8 @@ demo:
 | style | 列的样式 | `CSSProperties` | - |
 | onCell | 设置单元格属性 | `(record, index) => HTMLAttributes` | - |
 | onHeaderCell | 设置头部单元格属性 | `(column) => HTMLAttributes` | - |
-| resize | 列宽拖拽配置 | `{ resizable?: boolean; minWidth?: number; maxWidth?: number }` | - |
 | resizable | 是否可拖拽调整列宽，覆盖 Table.resizable | `boolean` | - |
-| minWidth | 最小列宽（拖拽限制） | `number` | `60` |
+| minWidth | 最小列宽（拖拽与弹性收缩的下限） | `number` | `60` |
 | maxWidth | 最大列宽（拖拽限制） | `number` | - |
 | onResize | 列宽变化回调 | `(width: number) => void` | - |
 | editable | 可编辑配置，可为 `boolean` 或详细配置对象 | `boolean \| EditableConfig` | - |

--- a/components/table/shared/utils/legacyUtil.ts
+++ b/components/table/shared/utils/legacyUtil.ts
@@ -1,7 +1,32 @@
 import warning from 'rc-util/lib/warning';
-import type { ExpandableConfig, LegacyExpandableProps } from '../../interface';
+import { INTERNAL_COLUMN_DEFAULT_WIDTH } from '../../constant';
+import type { ColumnType, ExpandableConfig, LegacyExpandableProps } from '../../interface';
 
 export const INTERNAL_COL_DEFINE = 'RC_TABLE_INTERNAL_COL_DEFINE';
+
+/** 读取内部注入列（选择列 / 展开列）的 columnType 标记 */
+export function getInternalColumnType<RecordType>(
+  column: ColumnType<RecordType>,
+): string | undefined {
+  return (column as Record<string, any>)?.[INTERNAL_COL_DEFINE]?.columnType;
+}
+
+/**
+ * 是否为 "auto 宽度" 内部列：由内部功能注入（选择列 / 展开列）且未显式设置 width。
+ * auto 列在虚拟模式下不参与弹性宽度分配，宽度由 CSS 类驱动并经测量管线同步。
+ */
+export function isAutoWidthColumn<RecordType>(column: ColumnType<RecordType>): boolean {
+  const columnType = getInternalColumnType(column);
+  return (
+    columnType != null && columnType in INTERNAL_COLUMN_DEFAULT_WIDTH && column.width == null
+  );
+}
+
+/** auto 内部列的首帧提示宽度（见 INTERNAL_COLUMN_DEFAULT_WIDTH） */
+export function getAutoColumnHintWidth<RecordType>(column: ColumnType<RecordType>): number {
+  const columnType = getInternalColumnType(column);
+  return (columnType && INTERNAL_COLUMN_DEFAULT_WIDTH[columnType]) || 0;
+}
 
 export function getExpandableProps<RecordType>(
   props: LegacyExpandableProps<RecordType> & {

--- a/components/table/style/resize.less
+++ b/components/table/style/resize.less
@@ -13,6 +13,12 @@
 .@{table-prefix-cls}-thead > tr > th.@{table-prefix-cls}-cell-resizable {
   position: relative;
   overflow: visible;
+
+  // fixed 列场景：右侧相邻固定列的 z-index 更高（fixUtil 的 zIndexReverse 向右递增），
+  // 会遮盖探出单元格边界的手柄高亮；hover 时提升当前 th 层级压过相邻固定列
+  &:hover {
+    z-index: calc(var(--z-offset-reverse, 0) + @table-z-index-fixed + 2);
+  }
 }
 
 // 拖拽手柄（通过 transformResizableColumns 注入到 title 中）
@@ -65,10 +71,12 @@
 }
 
 // 拖拽时的竖线指示器（绝对定位在表格容器内）
+// z-index 按列数计算：必须压过固定列（--z-offset-reverse + 2，最大约 N + 2）
+// 和容器边缘阴影 / sticky 层级（2N + 3，见 fixed.less / sticky.less）
 .@{table-prefix-cls}-resize-line {
   position: absolute;
   top: 0;
-  z-index: 10;
+  z-index: calc(var(--columns-count, 0) * 2 + @table-z-index-fixed + 2);
   display: none;
   width: 2px;
   margin-left: -1px;


### PR DESCRIPTION
### 🔗 关联 issue / Related issue

- close #29

### 💡 变更类型 / Type of change

- [x] 🐛 Bug fix（修复问题）
- [x] 📖 Documentation（文档）
- [x] 🧪 Tests（测试）

### 📝 变更描述 / Description

修复 Table 在虚拟滚动模式下列宽计算错乱、表头与 body 错位、resize 手柄被固定列遮盖等多个列宽相关缺陷，并统一列宽分配语义。

### 📋 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix column width calculation defects in virtual scrolling: selection/expand columns no longer get stretched to ~1700px or crushed to 1px; header and body columns are now aligned; resize handle/line no longer covered by fixed columns (`z-index` computed by column count). Unify width semantics — `width` is a lower bound (only grows), columns without `width` are flexible (shrink down to `minWidth`, default 60, no longer collapse to 1px), explicit `width` columns are no longer flex-shrunk. `columnWidth` now supports number / numeric string / percentage (relative to `scroll.x`). `showHeader={false}` can still measure internal column widths. |
| 🇨🇳 Chinese | 修复虚拟滚动下列宽计算缺陷：选择列/展开列不再被弹性分配为 1700px 或压至 1px；表头与 body 列宽对齐；resize 竖线与手柄不再被固定列遮盖（`z-index` 按列数计算）。统一列宽语义——`width` 为下限只增不减，无 `width` 列为弹性列（收缩下限 `minWidth` 默认 60，不再塌陷为 1px），显式 `width` 列不再被弹性收缩。`columnWidth` 支持数字/数字字符串/百分比（相对 `scroll.x`）。`showHeader={false}` 时仍能测量内部列宽。 |

### 📸 截图 / Screenshots

<!-- 列宽修复前后对比、resize 手柄可见性对比，可在 demo「虚拟滚动」中验证 -->

### ✅ 自检清单 / Self Checklist

- [x] 代码已本地验证通过（`tsc --noEmit` + `eslint` + `jest components/table`）
- [x] 相关文档或 demo 已更新（`index.md` 新增列宽规则说明，移除未实现的 `resize` 对象参数）
- [x] 新增/修改的代码已补充测试（新增 `VirtualAutoColumnWidth.test.tsx`，扩展 `Resize.test.tsx`）
- [x] 不影响现有功能

### 📌 主要改动 / Key changes

- **`useWidthColumns`**：统一列宽分配，`width` 为下限只增不减，无宽列弹性分配并收缩至 `minWidth`（默认 60）。
- **`useAutoColumnMeasure`**（新增）：测量管线，将内部列实测宽度同步进虚拟滚动网格计算。
- **`BodyGrid`**：移除 `minWidth` 兜底，与表头同源；resize 总宽计入内部功能列；`expand` 列在末尾时滚动条补偿前移。
- **`useResize`**：`z-index` 按列数计算，修复竖线/手柄被固定列遮盖。
- **`legacyUtil`**：`columnWidth` 支持数字、数字字符串、百分比（相对 `scroll.x`）解析。
- **`constant.ts`**（新增）：`INTERNAL_COLUMN_DEFAULT_WIDTH`（选择列 32 / 展开列 48）、`VIRTUAL_MISSING_WIDTH_COLUMN_MIN`（60）。
- **`FixedHolder` / `RcTable` / `useColumns` / `useSelection`**：内部列宽度改由 CSS 类驱动，`showHeader={false}` 时通过隐藏探针测量。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved column resizing with more accurate width distribution, minimum-width handling, and support for fixed selection and expand columns.
  * Enhanced virtual tables to automatically measure and apply internal column widths.
  * Improved layout behavior for fixed headers, hidden headers, and summary rows.

* **Bug Fixes**
  * Prevented explicit-width columns from shrinking unexpectedly.
  * Corrected resize indicator layering and column alignment during resizing.

* **Documentation**
  * Updated column width and resizing guidance, including elastic sizing and default internal-column widths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->