### PR TITLE
feat(table): 支持 RTL 从右到左布局 (#30)

### DIFF
--- a/components/table/InternalTable.tsx
+++ b/components/table/InternalTable.tsx
@@ -995,7 +995,7 @@ direction,
   const wrappercls = clsx(
     `${prefixCls}-wrapper`,
     {
-      [`${prefixCls}-wrapper-rtl`]: false,
+      [`${prefixCls}-wrapper-rtl`]: direction === 'rtl',
       [`${prefixCls}-middle`]: customizeSize === 'middle',
       [`${prefixCls}-small`]: customizeSize === 'small',
       [`${prefixCls}-wrapper-resizing`]: resizeResult.resizingKey != null,

--- a/components/table/InternalTable.tsx
+++ b/components/table/InternalTable.tsx
@@ -200,6 +200,7 @@ const InternalTable = <RecordType extends AnyObject = AnyObject>(
     showSorterTooltip = { target: 'full-header' },
     virtual,
     resizable = false,
+    direction: customizeDirection,
     onColumnResize: onColumnResizeProp,
     editable: editableEnabled = false,
     onEditableChange,
@@ -274,6 +275,12 @@ const InternalTable = <RecordType extends AnyObject = AnyObject>(
     [ariaProps, components?.header?.table],
   );
   const prefixCls = globalConfig().getPrefixCls('table', customizePrefixCls);
+
+  // RTL 方向：显式 direction prop > ConfigProvider.direction > 默认 ltr，
+  // 贯通到 RcTable 与列宽拖拽
+  const { direction: contextDirection } = React.useContext(ConfigContext);
+  const direction: 'ltr' | 'rtl' =
+    customizeDirection ?? (contextDirection === 'rtl' ? 'rtl' : 'ltr');
 
   // ============================= Refs =============================
   const rootRef = React.useRef<HTMLDivElement>(null);
@@ -363,6 +370,7 @@ const InternalTable = <RecordType extends AnyObject = AnyObject>(
     onColumnResize: onColumnResizeProp,
     prefixCls,
     extraFixedWidth: internalColumnsWidth,
+    direction,
   });
 
   const mergedComponents = React.useMemo<RcTableProps<RecordType>['components']>(() => {
@@ -376,12 +384,11 @@ const InternalTable = <RecordType extends AnyObject = AnyObject>(
     };
   }, [components, hasAriaProps]);
 
-  // Use antd@4 ConfigContext for locale and renderEmpty
   const {
     locale: contextLocale,
     renderEmpty,
     getPopupContainer: getContextPopupContainer,
-  } = React.useContext(ConfigContext) as any;
+  } = React.useContext(ConfigContext);
 
   const tableLocale: TableLocale = {
     filterTitle: 'Filter',
@@ -902,6 +909,7 @@ enabled: hasResizableColumns,
 isColumnResizable: resizeResult.isColumnResizable,
 onStartResize: resizeResult.onStartResize,
 onKeyboardResize: resizeResult.setColumnWidth,
+direction,
 });
       }
       return result;
@@ -915,6 +923,7 @@ onKeyboardResize: resizeResult.setColumnWidth,
       prefixCls,
       resizeResult.isColumnResizable,
       resizeResult.onStartResize,
+      direction,
     ],
   );
 
@@ -1060,7 +1069,7 @@ onKeyboardResize: resizeResult.setColumnWidth,
               onAutoColumnMeasure={handleAutoColumnMeasure}
               ref={tblRef}
               columns={finalColumns as RcTableProps<RecordType>['columns']}
-              direction={'ltr'}
+              direction={direction}
               expandable={mergedExpandable}
               prefixCls={prefixCls}
               className={clsx({

--- a/components/table/__tests__/Resize.test.tsx
+++ b/components/table/__tests__/Resize.test.tsx
@@ -1213,3 +1213,63 @@ describe('Resize — Measure Row Handle Focus', () => {
     });
   });
 });
+
+// ============================================================
+// Resize — RTL
+// ============================================================
+describe('Resize — RTL', () => {
+  beforeEach(() => {
+    mockElementWidths(200, 1000);
+  });
+  afterEach(() => {
+    restoreElementWidths();
+  });
+
+  it('mirrors drag delta in RTL (dragging left widens the column)', () => {
+    const onColumnResize = jest.fn();
+    const { container } = render(
+      <Table
+        dataSource={data}
+        columns={baseColumns}
+        rowKey="key"
+        resizable
+        direction="rtl"
+        onColumnResize={onColumnResize}
+      />,
+    );
+
+    // RTL 下手柄在列左缘：向左拖 50px（delta=-50）应变宽 → 200 + 50 = 250
+    simulateDrag(container, -50, 0);
+    expect(onColumnResize).toHaveBeenCalledWith('name', 250);
+  });
+
+  it('mirrors keyboard arrows in RTL (ArrowLeft widens)', () => {
+    const onColumnResize = jest.fn();
+    const { container } = render(
+      <Table
+        dataSource={data}
+        columns={baseColumns}
+        rowKey="key"
+        resizable
+        direction="rtl"
+        onColumnResize={onColumnResize}
+      />,
+    );
+
+    const handle = container.querySelector('.ant-table-resize-handle') as HTMLElement;
+    // RTL：ArrowLeft 变宽（offsetWidth mock 200 → 210）
+    fireEvent.keyDown(handle, { key: 'ArrowLeft' });
+    expect(onColumnResize).toHaveBeenCalledWith('name', 210);
+
+    // RTL：ArrowRight 变窄（200 → 190）
+    fireEvent.keyDown(handle, { key: 'ArrowRight' });
+    expect(onColumnResize).toHaveBeenCalledWith('name', 190);
+  });
+
+  it('honors direction prop over default ltr and renders rtl class', () => {
+    const { container } = render(
+      <Table dataSource={data} columns={baseColumns} rowKey="key" direction="rtl" resizable />,
+    );
+    expect(container.querySelector('.ant-table-rtl')).toBeInTheDocument();
+  });
+});

--- a/components/table/demos/rtl.tsx
+++ b/components/table/demos/rtl.tsx
@@ -1,0 +1,71 @@
+import { Radio, Space, Typography } from 'antd';
+import type { TableProps } from '@dtjoy/dt-design';
+import { Table } from '@dtjoy/dt-design';
+import React from 'react';
+
+interface RecordType {
+  id: number;
+  name: string;
+  department: string;
+  position: string;
+  salary: number;
+  email: string;
+}
+
+const columns: TableProps<RecordType>['columns'] = [
+  { title: 'ID', dataIndex: 'id', width: 80, fixed: 'start', resizable: true },
+  { title: '姓名', dataIndex: 'name', width: 120, fixed: 'start', resizable: true },
+  { title: '部门', dataIndex: 'department', width: 140, resizable: true },
+  { title: '职位', dataIndex: 'position', width: 140, resizable: true },
+  { title: '薪资', dataIndex: 'salary', width: 140, align: 'right', resizable: true },
+  { title: '邮箱', dataIndex: 'email', resizable: true },
+  {
+    title: '操作',
+    key: 'action',
+    width: 120,
+    fixed: 'end',
+    render: () => <Typography.Link>编辑</Typography.Link>,
+  },
+];
+
+const data: RecordType[] = Array.from({ length: 1000 }, (_, i) => ({
+  id: 1000 + i,
+  name: `员工_${i + 1}`,
+  department: ['技术部', '产品部', '设计部', '运营部'][i % 4],
+  position: ['工程师', '经理', '总监', '主管'][i % 4],
+  salary: 15000 + (i % 20) * 1000,
+  email: `user${i + 1}@example.com`,
+}));
+
+const App: React.FC = () => {
+  const [direction, setDirection] = React.useState<'ltr' | 'rtl'>('ltr');
+
+  return (
+    <Space direction="vertical" style={{ width: '100%' }}>
+      <Radio.Group
+        value={direction}
+        onChange={(e) => setDirection(e.target.value)}
+        optionType="button"
+        buttonStyle="solid"
+        options={[
+          { label: 'LTR 从左到右', value: 'ltr' },
+          { label: 'RTL 从右到左', value: 'rtl' },
+        ]}
+      />
+      <Table<RecordType>
+        bordered
+        virtual
+        resizable
+        direction={direction}
+        columns={columns}
+        dataSource={data}
+        rowKey="id"
+        scroll={{ x: 1200, y: 400 }}
+        pagination={false}
+        rowSelection={{ type: 'checkbox', fixed: 'start' }}
+      />
+    </Space>
+  );
+};
+
+export default App;

--- a/components/table/features/resize/ResizeHandle.tsx
+++ b/components/table/features/resize/ResizeHandle.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import TableMeasureRowContext from '../../TableMeasureRowContext';
-import type { ColumnType } from '../../interface';
+import type { ColumnType, Direction } from '../../interface';
 
 export interface ResizeHandleProps {
   /** 列对象 */
@@ -11,6 +11,8 @@ export interface ResizeHandleProps {
   onKeyboardResize: (col: ColumnType, newWidth: number) => void;
   /** prefixCls */
   prefixCls: string;
+  /** RTL 下手柄在列左缘，键盘方向键语义镜像 */
+  direction?: Direction;
 }
 
 /** 键盘步进(px) */
@@ -29,8 +31,11 @@ const ResizeHandle: React.FC<ResizeHandleProps> = ({
   onStartResize,
   onKeyboardResize,
   prefixCls,
+  direction,
 }) => {
   const inMeasureRow = React.useContext(TableMeasureRowContext);
+  // RTL 下手柄在列左缘，左右方向键语义镜像
+  const isRtl = direction === 'rtl';
 
   const handleMouseDown = React.useCallback(
     (e: React.MouseEvent) => {
@@ -57,12 +62,16 @@ const ResizeHandle: React.FC<ResizeHandleProps> = ({
       const minWidth = column.minWidth ?? 60;
       const maxWidth = column.maxWidth;
 
+      // LTR：ArrowLeft 变窄 / ArrowRight 变宽；RTL 手柄在左缘，语义镜像
+      const shrinkKey = isRtl ? 'ArrowRight' : 'ArrowLeft';
+      const growKey = isRtl ? 'ArrowLeft' : 'ArrowRight';
+
       switch (e.key) {
-        case 'ArrowLeft':
+        case shrinkKey:
           e.preventDefault();
           onKeyboardResize(column, currentWidth - KEYBOARD_STEP);
           break;
-        case 'ArrowRight':
+        case growKey:
           e.preventDefault();
           onKeyboardResize(column, currentWidth + KEYBOARD_STEP);
           break;
@@ -76,7 +85,7 @@ const ResizeHandle: React.FC<ResizeHandleProps> = ({
           break;
       }
     },
-    [column, onKeyboardResize],
+    [column, onKeyboardResize, isRtl],
   );
 
   // aria 属性需要数值类型

--- a/components/table/features/resize/ResizeHandle.tsx
+++ b/components/table/features/resize/ResizeHandle.tsx
@@ -48,7 +48,7 @@ const ResizeHandle: React.FC<ResizeHandleProps> = ({
       const actualWidth = th ? th.offsetWidth : undefined;
       onStartResize(e, column, actualWidth);
     },
-    [column, onStartResize],
+    [column, onStartResize, inMeasureRow],
   );
 
   const handleKeyDown = React.useCallback(
@@ -85,7 +85,7 @@ const ResizeHandle: React.FC<ResizeHandleProps> = ({
           break;
       }
     },
-    [column, onKeyboardResize, isRtl],
+    [column, onKeyboardResize, isRtl, inMeasureRow],
   );
 
   // aria 属性需要数值类型

--- a/components/table/features/resize/transformResizableColumns.tsx
+++ b/components/table/features/resize/transformResizableColumns.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import type { ColumnGroupType, ColumnsType, ColumnType } from '../../interface';
+import type { ColumnGroupType, ColumnsType, ColumnType, Direction } from '../../interface';
 import ResizeHandle from './ResizeHandle';
 
 export interface TransformResizableOptions {
@@ -8,13 +8,16 @@ export interface TransformResizableOptions {
   isColumnResizable: (col: ColumnType) => boolean;
   onStartResize: (e: React.MouseEvent, col: ColumnType, actualWidth?: number) => void;
   onKeyboardResize: (col: ColumnType, newWidth: number) => void;
+  /** RTL 下手柄在列左缘，键盘方向键语义镜像 */
+  direction?: Direction;
 }
 
 function transformResizableColumns<RecordType = any>(
   columns: ColumnsType<RecordType>,
   options: TransformResizableOptions,
 ): ColumnsType<RecordType> {
-  const { prefixCls, enabled, isColumnResizable, onStartResize, onKeyboardResize } = options;
+  const { prefixCls, enabled, isColumnResizable, onStartResize, onKeyboardResize, direction } =
+    options;
 
   if (!enabled) return columns;
 
@@ -40,6 +43,7 @@ function transformResizableColumns<RecordType = any>(
             prefixCls={prefixCls}
             onStartResize={onStartResize}
             onKeyboardResize={onKeyboardResize}
+            direction={direction}
           />
         </>
       );

--- a/components/table/features/resize/useResize.ts
+++ b/components/table/features/resize/useResize.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import type { ColumnsType, ColumnType, Key } from '../../interface';
+import type { ColumnsType, ColumnType, Direction, Key } from '../../interface';
 
 export interface UseResizeOptions {
   columns: ColumnsType;
@@ -19,6 +19,8 @@ export interface UseResizeOptions {
    * 计入总宽可避免 scrollX 覆盖 scroll.x 后内容比预期宽出内部列宽。
    */
   extraFixedWidth?: number;
+  /** 文本方向：RTL 下手柄在列左缘，拖拽 delta 取反 */
+  direction?: Direction;
 }
 
 /**
@@ -67,6 +69,7 @@ function useResize({
   onColumnResize,
   prefixCls,
   extraFixedWidth = 0,
+  direction = 'ltr',
 }: UseResizeOptions) {
   // 扁平化列（仅叶子列可以 resize）
   const flattenColumns = React.useMemo(() => {
@@ -456,8 +459,10 @@ function useResize({
           if (!dragRef.current) return;
           dragRef.current.rafId = null;
 
-          // 使用最新存储的 clientX 计算，而非闭包中的 ev
-          const delta = dragRef.current.latestClientX - dragRef.current.startX;
+          // 使用最新存储的 clientX 计算，而非闭包中的 ev。
+          // RTL 下手柄在列左缘：向左拖（delta 为负）变宽，delta 取反
+          const rawDelta = dragRef.current.latestClientX - dragRef.current.startX;
+          const delta = direction === 'rtl' ? -rawDelta : rawDelta;
           let newWidth = dragRef.current.startWidth + delta;
           newWidth = Math.max(newWidth, dragRef.current.minWidth);
           if (dragRef.current.maxWidth != null) {
@@ -538,7 +543,7 @@ function useResize({
         document.removeEventListener('mouseup', onUp);
       };
     },
-    [getResizeConfig, updateLinePosition, hideLine],
+    [getResizeConfig, updateLinePosition, hideLine, direction],
   );
 
   // 获取列的渲染宽度（= 用户宽度 + 剩余空间分配）

--- a/components/table/index.md
+++ b/components/table/index.md
@@ -57,6 +57,8 @@ demo:
 
 <code src="./demos/sticky.tsx" description="通过 `sticky` 属性让表头在页面滚动时粘性吸顶。">粘性表头</code>
 
+<code src="./demos/rtl.tsx" description="通过 `direction` 或 ConfigProvider 切换 RTL（从右到左）布局，固定列、选择列、列宽拖拽均支持方向镜像。">RTL 从右到左</code>
+
 ## 展开与树形
 
 <code src="./demos/expand-row.tsx" description="通过 `expandable.expandedRowRender` 实现行展开功能。">行展开</code>
@@ -120,6 +122,7 @@ demo:
 | bordered | 是否展示外边框和列边框 | `boolean` | `false` |
 | size | 表格大小 | `large \| middle \| small` | `large` |
 | showHeader | 是否显示表头 | `boolean` | `true` |
+| direction | 表格文本方向，默认跟随 `ConfigProvider` 的 `direction` 配置 | `ltr \| rtl` | `ltr` |
 | title | 表格标题 | `(data) => ReactNode` | - |
 | footer | 表格页脚 | `(data) => ReactNode` | - |
 | summary | 表格总结栏 | `(data) => ReactNode` | - |

--- a/components/table/style/resize.less
+++ b/components/table/style/resize.less
@@ -61,6 +61,30 @@
   }
 }
 
+// RTL：手柄镜像到列左缘
+.@{table-prefix-cls}-rtl {
+  .@{table-prefix-cls}-resize-handle {
+    right: auto;
+    left: -5px;
+
+    &::after {
+      right: auto;
+      left: 4px;
+    }
+  }
+
+  // RTL 下 DOM 最后一列是视觉最左列，手柄限制在单元格内
+  .@{table-prefix-cls}-thead > tr > th:last-child .@{table-prefix-cls}-resize-handle {
+    right: auto;
+    left: 0;
+
+    &:hover::after {
+      right: auto;
+      left: 0;
+    }
+  }
+}
+
 // 拖拽进行中时，通过 wrapper 级联隐藏所有 hover 高亮
 .@{table-prefix-cls}-wrapper-resizing {
   .@{table-prefix-cls}-resize-handle::after,


### PR DESCRIPTION
### 🔗 关联 issue / Related issue

- close #30

### 💡 变更类型 / Type of change

- [x] 🆕 New feature（新功能）
- [x] 📖 Documentation（文档）
- [ ] 🧪 Tests（测试）

### 📝 变更描述 / Description

为 Table 新增 RTL（从右到左）布局支持：通过 `direction` prop 或 `ConfigProvider.direction` 切换方向，固定列、选择列、展开列、列宽拖拽均镜像方向。

> **Stacked PR**：本 PR 基于 #29（列宽修复）之上，base 暂设为 `fix/table-column-width`。#29 合并后可将本 PR base 改回 `main`。

### 📋 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Table now supports RTL (right-to-left) layout via `direction` prop or `ConfigProvider.direction`. Fixed columns, selection columns, expand columns, and column resize all mirror direction in RTL. Resize handle mirrors to the left edge of the column; drag delta and keyboard ←/→ semantics are mirrored. Priority: `direction` prop > `ConfigProvider.direction` > default `ltr`. |
| 🇨🇳 Chinese | Table 新增 RTL（从右到左）布局支持，通过 `direction` prop 或 `ConfigProvider.direction` 切换。固定列、选择列、展开列、列宽拖拽均镜像方向。拖拽手柄镜像到列左缘，拖拽 `delta` 与键盘 ←/→ 语义镜像。优先级：`direction` prop > `ConfigProvider.direction` > 默认 `ltr`。 |

### 📸 截图 / Screenshots

<!-- RTL demo 截图，可见 `demos/rtl.tsx` -->

### ✅ 自检清单 / Self Checklist

- [x] 代码已本地验证通过（`tsc --noEmit` + `eslint` + `jest components/table`）
- [x] 相关文档或 demo 已更新（新增 `demos/rtl.tsx`，`index.md` 补充 `direction` API 与 RTL demo 入口）
- [x] 新增/修改的代码已补充测试（`Resize.test.tsx` 新增方向镜像测试）
- [x] 不影响现有功能（默认 `ltr`，行为不变）

### 📌 主要改动 / Key changes

- **`InternalTable`**：新增 `direction` prop，优先级 `direction` > `ConfigProvider.direction` > `ltr`，修复硬编码 `ltr` 覆盖问题。
- **`ResizeHandle` / `transformResizableColumns` / `useResize`**：RTL 下手柄镜像到列左缘，拖拽 `delta` 与键盘 ←/→ 语义镜像。
- **`style/resize.less`**：RTL 下手柄定位与视觉镜像。
- **`demos/rtl.tsx`**（新增）：RTL 示例 demo。
- **`index.md`**：API 表补充 `direction`，新增 RTL demo 入口。
- **`Resize.test.tsx`**：新增方向镜像测试。
