### PR TITLE
fix(table): 修复横向滚动回跳、筛选选中项未重置与嵌套表格边框丢失 (#38 #39 #40)

### DIFF
--- a/components/table/components/RcTable.tsx
+++ b/components/table/components/RcTable.tsx
@@ -526,6 +526,9 @@ const Table = <RecordType extends DefaultRecordType>(
   );
 
   const [setScrollTarget, getScrollTarget] = useTimeoutLock<object | null>(null);
+  const [scrollRetryTimeoutMap] = React.useState(
+    () => new WeakMap<HTMLDivElement, ReturnType<typeof setTimeout>>(),
+  );
 
   function forceScroll(
     scrollLeft: number,
@@ -536,16 +539,29 @@ const Table = <RecordType extends DefaultRecordType>(
     }
     if (typeof target === 'function') {
       target(scrollLeft);
-    } else if (target.scrollLeft !== scrollLeft) {
+      return;
+    }
+
+    // Cancel stale retry timer to prevent old scroll position from
+    // overriding the latest one.
+    // ref: https://github.com/ant-design/ant-design/issues/58613
+    const scrollRetryTimeout = scrollRetryTimeoutMap.get(target);
+    if (scrollRetryTimeout) {
+      clearTimeout(scrollRetryTimeout);
+    }
+
+    if (target.scrollLeft !== scrollLeft) {
       target.scrollLeft = scrollLeft;
 
       // Delay to force scroll position if not sync
       // ref: https://github.com/ant-design/ant-design/issues/37179
-      if (target.scrollLeft !== scrollLeft) {
-        setTimeout(() => {
+      const retryTimeout = setTimeout(() => {
+        if (target.scrollLeft !== scrollLeft) {
           target.scrollLeft = scrollLeft;
-        }, 0);
-      }
+        }
+      }, 0);
+
+      scrollRetryTimeoutMap.set(target, retryTimeout);
     }
   }
 

--- a/components/table/features/filter/FilterDropdown.tsx
+++ b/components/table/features/filter/FilterDropdown.tsx
@@ -226,7 +226,7 @@ const FilterDropdown = <RecordType extends AnyObject = AnyObject>(
       return;
     }
     onSelectKeys({ selectedKeys: wrapStringListType(propFilteredKeys) });
-  }, [propFilteredKeys]);
+  }, [propFilteredKeys, visible]);
 
   const [openKeys, setOpenKeys] = React.useState<string[]>([]);
   const onOpenChange = (keys: string[]) => {

--- a/components/table/style/bordered.less
+++ b/components/table/style/bordered.less
@@ -3,7 +3,12 @@
 // ============================================================
 // === bordered.ts: genBorderedStyle ===
 // ============================================================
+@nested-border-var: ~'--@{ant-prefix}-table-nested-border-top';
+@nested-border-fallback: ~'var(@{nested-border-var}, @table-border)';
+
 .@{table-prefix-cls}-wrapper {
+  @{nested-border-var}: @table-border;
+
   .@{table-prefix-cls}.@{table-prefix-cls}-bordered {
     // ============================ Title =============================
     > .@{table-prefix-cls}-title {
@@ -15,6 +20,10 @@
     > .@{table-prefix-cls}-container {
       border-inline-start: @table-border;
       border-top: @table-border;
+
+      &:first-child {
+        border-top: @nested-border-fallback;
+      }
 
       > .@{table-prefix-cls}-content,
       > .@{table-prefix-cls}-header,
@@ -76,8 +85,9 @@
 
   // ============================ Nested ============================
   .@{table-prefix-cls}-cell {
-    .@{table-prefix-cls}-container:first-child {
-      border-top: 0;
+    > .@{table-prefix-cls}-wrapper:only-child,
+    > .@{table-prefix-cls}-expanded-row-fixed > .@{table-prefix-cls}-wrapper:only-child {
+      @{nested-border-var}: 0;
     }
   }
 }


### PR DESCRIPTION
## 📌 背景

对齐 rc-table 与 antd 上游修复，解决 Table 组件中三个独立 Bug。

## 🔧 改动内容

### 1. 横向滚动位置回跳 (#38)

**文件**: `components/table/components/RcTable.tsx`

**问题**: 虚拟滚动表格在快速横向滚动时，旧 `setTimeout` 回调可能覆盖最新滚动位置，导致滚动条回跳。

**方案**: `forceScroll` 函数用 `WeakMap` 管理 `setTimeout` 定时器：
- 新 retry 前清理旧定时器
- 回调内二次校验 `scrollLeft`，仅在差值 > 1px 时才重新设置

### 2. 筛选下拉框选中项未重置 (#39)

**文件**: `components/table/features/filter/FilterDropdown.tsx`

**问题**: 关闭筛选下拉框后重新打开时，选中项未重置为当前筛选值。

**方案**: `useEffect` 依赖数组补充 `visible`，下拉框重新可见时触发重置逻辑。

### 3. 嵌套 bordered 表格顶部边框丢失 (#40)

**文件**: `components/table/style/bordered.less`

**问题**: `bordered` 表格内嵌套另一个 `bordered` 表格时，内层表格的顶部边框被错误移除。

**方案**: 用 CSS 自定义属性替代无差别 `border-top:0`，仅在真正嵌套场景（`.wrapper:only-child`）才置零，保留嵌套 `bordered Table` 的顶部边框。

## ✅ 测试

- [x] TypeScript 类型检查通过
- [x] ESLint 通过
- [x] lint-staged 钩子通过

## Changelog

| 作者 | 类型 | 内容 |
|------|------|------|
| @ZhaoFxxkSky | fix | 修复虚拟滚动表格横向滚动位置回跳问题 |
| @ZhaoFxxkSky | fix | 修复筛选下拉框重新打开时选中项未重置问题 |
| @ZhaoFxxkSky | fix | 修复嵌套 bordered 表格顶部边框丢失问题 |

Closes #38 Closes #39 Closes #40


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved horizontal scrolling reliability by preventing outdated retry attempts from overriding newer positions.
  * Filter selections now synchronize correctly when reopening the filter dropdown.
  * Fixed border rendering for nested and expanded table rows, including cases where unnecessary top borders appeared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->