### PR TITLE
refactor(table): 提取 useColumnTitleProps 与 useSpinProps (#41)

### DIFF
--- a/components/table/InternalTable.tsx
+++ b/components/table/InternalTable.tsx
@@ -3,7 +3,6 @@ import { INTERNAL_COLUMN_DEFAULT_WIDTH, INTERNAL_HOOKS } from './constant';
 import { convertChildrenToColumns } from './features/columns/useColumns';
 import type {
   ColumnsType,
-  ColumnTitleProps,
   ColumnType,
   EditableValidateResult,
   ExpandableConfig,
@@ -43,6 +42,7 @@ import { Pagination, Spin } from 'antd';
 import { ConfigContext, globalConfig } from 'antd/lib/config-provider';
 import enUS from 'antd/lib/locale/en_US';
 import renderExpandIcon from './components/ExpandIcon';
+import useColumnTitleProps from './hooks/useColumnTitleProps';
 import useContainerWidth from './shared/hooks/useContainerWidth';
 import useFilledColumns from './features/columns/useFilledColumns';
 import type { FilterConfig, FilterState } from './features/filter/useFilter';
@@ -55,6 +55,7 @@ import usePagination, {
 import useSelection from './features/selection/useSelection';
 import type { SortState } from './features/sort/useSorter';
 import useSorter, { getSortData } from './features/sort/useSorter';
+import useSpinProps from './hooks/useSpinProps';
 import useTitleColumns from './features/columns/useTitleColumns';
 
 import RcTable from './components/RcTable';
@@ -758,18 +759,7 @@ const InternalTable = <RecordType extends AnyObject = AnyObject>(
   changeEventInfo.filterStates = filterStates;
 
   // ============================ Column ============================
-  const columnTitleProps = React.useMemo<ColumnTitleProps<RecordType>>(() => {
-    const mergedFilters: Record<string, FilterValue> = {};
-    Object.keys(filters).forEach((filterKey) => {
-      if (filters[filterKey] !== null) {
-        mergedFilters[filterKey] = filters[filterKey]!;
-      }
-    });
-    return {
-      ...sorterTitleProps,
-      filters: mergedFilters,
-    };
-  }, [sorterTitleProps, filters]);
+  const columnTitleProps = useColumnTitleProps<RecordType>(sorterTitleProps, filters);
 
   const [transformTitleColumns] = useTitleColumns(columnTitleProps);
 
@@ -970,15 +960,7 @@ const InternalTable = <RecordType extends AnyObject = AnyObject>(
   }
 
   // >>>>>>>>> Spinning
-  const spinProps = React.useMemo<SpinProps | undefined>(() => {
-    if (typeof loading === 'boolean') {
-      return { spinning: loading };
-    } else if (isPlainObject(loading)) {
-      return { spinning: true, ...loading };
-    } else {
-      return undefined;
-    }
-  }, [loading]);
+  const spinProps = useSpinProps(loading);
 
   const wrappercls = clsx(
     `${prefixCls}-wrapper`,

--- a/components/table/hooks/useColumnTitleProps.ts
+++ b/components/table/hooks/useColumnTitleProps.ts
@@ -1,0 +1,30 @@
+import React from 'react';
+
+import { isNonNullable } from '../../_util/is';
+import type { AnyObject } from '../../_util/type';
+import type { ColumnTitleProps, FilterValue } from '../interface';
+
+const getMergedFilters = (filters: Record<string, FilterValue | null>) => {
+  const mergedFilters: Record<string, FilterValue> = {};
+  for (const [key, value] of Object.entries(filters)) {
+    if (isNonNullable(value)) {
+      mergedFilters[key] = value;
+    }
+  }
+  return mergedFilters;
+};
+
+const useColumnTitleProps = <RecordType extends AnyObject = AnyObject>(
+  sorterTitleProps: ColumnTitleProps<RecordType>,
+  filters: Record<string, FilterValue | null>,
+) => {
+  const columnTitleProps = React.useMemo<ColumnTitleProps<RecordType>>(() => {
+    return {
+      ...sorterTitleProps,
+      filters: getMergedFilters(filters),
+    };
+  }, [sorterTitleProps, filters]);
+  return columnTitleProps;
+};
+
+export default useColumnTitleProps;

--- a/components/table/hooks/useSpinProps.ts
+++ b/components/table/hooks/useSpinProps.ts
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import { isPlainObject } from '../../_util/is';
+import type { SpinProps } from 'antd';
+
+const useSpinProps = (loading?: boolean | SpinProps) => {
+  const spinProps = React.useMemo<SpinProps>(() => {
+    if (typeof loading === 'boolean') {
+      return { spinning: loading };
+    }
+    if (isPlainObject<SpinProps>(loading)) {
+      return { spinning: true, ...loading };
+    }
+    return {};
+  }, [loading]);
+  return spinProps;
+};
+
+export default useSpinProps;


### PR DESCRIPTION
## 📌 背景

`InternalTable.tsx` 文件已达 1000+ 行，内聚了列标题处理、筛选合并、loading 规范化等多种逻辑，可维护性下降。参考 antd 上游 `a7a37ce` 的重构方向，将内部逻辑拆分为独立 Hook。

## 🔧 改动内容

### 1. 提取 `useColumnTitleProps`

**新文件**: `components/table/hooks/useColumnTitleProps.ts`

**职责**: 负责列标题（`columnTitle`）与筛选状态（`filterValue`）的合并逻辑，使用 `isNonNullable` 保证类型安全。

### 2. 提取 `useSpinProps`

**新文件**: `components/table/hooks/useSpinProps.ts`

**职责**: 负责 `loading` / `spin` 属性的规范化，确保空 loading 状态返回 `{}` 而非 `undefined`，避免下游展开语法报错。

### 3. `InternalTable.tsx` 精简

- 移除内联逻辑，改为引用两个新 Hook
- 移除未使用的 `ColumnTitleProps` import

## ✅ 测试

- [x] TypeScript 类型检查通过
- [x] ESLint 通过
- [x] lint-staged 钩子通过

## Changelog

| 作者 | 类型 | 内容 |
|------|------|------|
| @ZhaoFxxkSky | refactor | 提取 useColumnTitleProps 与 useSpinProps，降低 InternalTable 复杂度 |

Closes #41
