### PR TITLE
fix(ci): 修复 Issue 模板 description 字段大小写导致模板不生效

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yml
@@ -1,5 +1,5 @@
 name: 🐛 Bug Report
-Description: 提交一个 Bug 报告
+description: 提交一个 Bug 报告
 title: '[Bug]: '
 labels: ['bug']
 body:

--- a/.github/ISSUE_TEMPLATE/2_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/2_feature_request.yml
@@ -1,7 +1,7 @@
 name: 💡 Feature Request
-Description: 提交一个新功能建议
+description: 提交一个新功能建议
 title: '[Feature]: '
-labels: ['feature']
+labels: ['enhancement']
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/3_question.yml
+++ b/.github/ISSUE_TEMPLATE/3_question.yml
@@ -1,5 +1,5 @@
 name: ❓ Question
-Description: 提出一个使用或咨询问题
+description: 提出一个使用或咨询问题
 title: '[Question]: '
 labels: ['question']
 body:


### PR DESCRIPTION
## 🔧 修复内容

GitHub Issue 模板中 `Description`（大写 D）不符合 Issue Forms 规范，导致三个模板全部校验失败被静默忽略，用户创建 Issue 时看不到任何模板。

### 根因

GitHub Issue Forms 要求顶级键必须为全小写 `description`。原模板使用 `Description`（大写 D），被解析器视为未知键，导致 `description` 必需字段缺失，模板校验失败。

### 改动

| 文件 | 改动 |
|------|------|
| `1_bug_report.yml` | `Description` → `description` |
| `2_feature_request.yml` | `Description` → `description`；`labels: ['feature']` → `labels: ['enhancement']`（仓库无 `feature` 标签） |
| `3_question.yml` | `Description` → `description` |

### 参考

- [GitHub Docs: Syntax for issue forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms)
- [GitHub Docs: Common validation errors](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/common-validation-errors-when-creating-issue-forms)

## Changelog

| Category | Description |
|----------|-------------|
| 🐛 Bug Fixes | 修复 Issue 模板 `description` 字段大小写错误导致模板不生效
